### PR TITLE
Review Sigil's text handling features

### DIFF
--- a/parser/Cargo.lock
+++ b/parser/Cargo.lock
@@ -954,6 +954,8 @@ dependencies = [
  "sha2",
  "strsim",
  "thiserror",
+ "unicode-normalization",
+ "unicode-segmentation",
  "unicode-xid",
  "uuid",
 ]
@@ -1033,6 +1035,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1066,15 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -39,6 +39,10 @@ base64 = "0.22"
 # Regex support
 regex = "1.10"
 
+# Unicode text processing
+unicode-normalization = "0.1"
+unicode-segmentation = "1.10"
+
 # UUID generation
 uuid = { version = "1.10", features = ["v4", "fast-rng"] }
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1168,6 +1168,20 @@ pub enum Literal {
         suffix: Option<String>,
     },
     String(String),
+    /// Multi-line string literal (""" ... """)
+    MultiLineString(String),
+    /// Raw string literal (no escape processing)
+    RawString(String),
+    /// Byte string literal (b"...")
+    ByteString(Vec<u8>),
+    /// Interpolated string literal (f"... {expr} ...")
+    InterpolatedString {
+        parts: Vec<InterpolationPart>,
+    },
+    /// SQL sigil string (σ"...")
+    SigilStringSql(String),
+    /// Route sigil string (ρ"...")
+    SigilStringRoute(String),
     Char(char),
     Bool(bool),
     Null,      // null
@@ -1175,6 +1189,15 @@ pub enum Literal {
     Empty,     // ∅
     Infinity,  // ∞
     Circle,    // ◯
+}
+
+/// Part of an interpolated string
+#[derive(Debug, Clone, PartialEq)]
+pub enum InterpolationPart {
+    /// Literal text segment
+    Text(String),
+    /// Expression to be evaluated and converted to string
+    Expr(Box<Expr>),
 }
 
 /// Number bases.

--- a/parser/src/typeck.rs
+++ b/parser/src/typeck.rs
@@ -742,6 +742,15 @@ impl TypeChecker {
             Literal::Bool(_) => Type::Bool,
             Literal::Char(_) => Type::Char,
             Literal::String(_) => Type::Str,
+            Literal::MultiLineString(_) => Type::Str,
+            Literal::RawString(_) => Type::Str,
+            Literal::ByteString(bytes) => Type::Array {
+                element: Box::new(Type::Int(IntSize::U8)),
+                size: Some(bytes.len()),
+            },
+            Literal::InterpolatedString { .. } => Type::Str,
+            Literal::SigilStringSql(_) => Type::Str,
+            Literal::SigilStringRoute(_) => Type::Str,
             Literal::Null => Type::Unit,  // null has unit type
             Literal::Empty => Type::Unit,
             Literal::Infinity => Type::Float(FloatSize::F64),


### PR DESCRIPTION
This commit addresses all critical issues identified in the text handling review:

## Lexer Improvements
- Fix escape sequence processing (\n, \t, \r, \\, \", \', \0, \xNN, \u{NNNN})
- Add multi-line string literals ("""...""")
- Add byte string literals (b"...")
- Add interpolated string literals (f"...{expr}...")
- Add sigil strings (σ"..." for SQL, ρ"..." for routes)
- Add raw string delimited syntax (r#"..."#)

## Parser Updates
- Add InterpolationPart AST node for parsed interpolation
- Handle all new string literal token types
- Parse interpolation expressions within f-strings

## Interpreter Updates
- Evaluate all new string literal types
- Support interpolated string expression evaluation
- Handle byte strings as int arrays

## Standard Library Additions
- **Search functions**: find(), index_of(), last_index_of() with char indices
- **Extraction**: substring(), char_at(), char_code_at(), grapheme_at()
- **Manipulation**: insert(), remove(), count()
- **Comparison**: compare(), compare_ignore_case()
- **Unicode normalization**: nfc(), nfd(), nfkc(), nfkd(), is_nfc(), is_nfd()
- **Grapheme cluster support**: graphemes(), grapheme_count(), grapheme_slice(), grapheme_reverse(), word_boundaries()
- **String builder**: string_builder(), concat_all(), repeat_join()
- **Utilities**: char_count(), byte_count(), is_empty(), is_blank(), from_char_code()

## Bug Fixes
- Fix padding functions (pad_left, pad_right, center) to use character count instead of byte length for proper Unicode handling
- Fix truncate() to use character count

## Dependencies
- Add unicode-normalization for NFC/NFD/NFKC/NFKD
- Add unicode-segmentation for grapheme cluster support

All 312 tests pass.