### PR TITLE
Add type-level evidentiality markers to parser

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -644,6 +644,8 @@ pub struct StructDef {
     pub visibility: Visibility,
     pub attrs: StructAttrs,
     pub name: Ident,
+    /// Type-level evidentiality marker: `struct Foo!`, `struct Bar~`, etc.
+    pub evidentiality: Option<Evidentiality>,
     pub generics: Option<Generics>,
     pub fields: StructFields,
 }
@@ -669,6 +671,8 @@ pub struct FieldDef {
 pub struct EnumDef {
     pub visibility: Visibility,
     pub name: Ident,
+    /// Type-level evidentiality marker: `enum Foo!`, `enum Bar~`, etc.
+    pub evidentiality: Option<Evidentiality>,
     pub generics: Option<Generics>,
     pub variants: Vec<EnumVariant>,
 }

--- a/parser/tests/evidentiality_type_level.sigil
+++ b/parser/tests/evidentiality_type_level.sigil
@@ -1,0 +1,35 @@
+struct UserInput~ {
+    username: str,
+    password: str,
+}
+
+struct ValidatedUser! {
+    username: str,
+    password_hash: str,
+}
+
+enum SafeValue! {
+    Int(i64),
+    Str(str),
+    Null,
+}
+
+enum ExternalMessage~ {
+    Text(str),
+    Binary([u8]),
+}
+
+struct RegularStruct {
+    x: i32,
+    y: i32,
+}
+
+enum RegularEnum {
+    A,
+    B,
+    C,
+}
+
+fn main() {
+    print("Test passed")
+}


### PR DESCRIPTION
…initions

Add support for evidentiality markers directly on struct and enum definitions, enabling syntax like `struct UserInput~` (reported/untrusted) and `struct ValidatedUser!` (known/validated).

This enables compile-time tracking of data trust levels for security- sensitive code, allowing patterns like:
- `struct UserInput~` - marks entire struct as untrusted external data
- `struct ValidatedUser!` - marks struct as validated/trusted
- `enum SafeValue!` - marks enum variants as known/safe

Changes:
- Add `evidentiality: Option<Evidentiality>` field to StructDef and EnumDef
- Parse evidentiality marker after struct/enum name in parser
- Add comprehensive unit tests for the new syntax
- Add test file demonstrating the feature