### PR TITLE
Fix parser rejection of self in method parameters

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -792,6 +792,7 @@ pub struct ActorDef {
     pub name: Ident,
     pub generics: Option<Generics>,
     pub state: Vec<FieldDef>,
+    pub methods: Vec<Function>,
     pub handlers: Vec<MessageHandler>,
 }
 
@@ -974,6 +975,11 @@ pub enum Expr {
     AddrOf { mutable: bool, expr: Box<Expr> },
     /// Cast: `expr as Type`
     Cast { expr: Box<Expr>, ty: TypeExpr },
+    /// Channel send: `channel <- value`
+    ChannelSend {
+        channel: Box<Expr>,
+        value: Box<Expr>,
+    },
 
     /// Inline assembly: `asm!("instruction", ...)`
     InlineAsm(InlineAsm),


### PR DESCRIPTION
…ents

This commit adds support for several missing parser features:

- Self parameters in methods: `fn foo(self)` and `fn bar(mut self)`
- Type paths with dot separator: `time.Duration` now parses correctly
- Compound assignment operators: `+=`, `-=`, `*=`, `/=`
- Channel send operator: `channel <- value`
- Type cast operator: `expr as Type`
- Actor methods: actors can now contain `fn` definitions
- Nested generics: `Option<Option<T>>` now parses correctly (handles >> vs > >)
- Tuple pattern closures: `{(x, y) => x + y}` in morpheme bodies
- Optional parentheses for parameterless message handlers: `on Reset { ... }`
- Comment skipping in actor definitions

These changes allow more official examples to parse successfully.