### PR TITLE
Fix remaining Rust parser incompatibilities

### DIFF
--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -875,6 +875,7 @@ impl Interpreter {
                 receiver,
                 method,
                 args,
+                ..
             } => self.eval_method_call(receiver, method, args),
             // Polysynthetic incorporation: path·file·read·string
             // Each segment is a method/function that transforms the value

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -256,6 +256,8 @@ pub enum Token {
     Derive,
     #[token("on")]
     On,
+    #[token("bitflags")]
+    Bitflags,
 
     // Boolean literals
     #[token("true")]

--- a/parser/src/lower.rs
+++ b/parser/src/lower.rs
@@ -127,7 +127,8 @@ fn lower_item(ctx: &mut LoweringContext, module: &mut IrModule, item: &ast::Item
         ast::Item::Static(_)
         | ast::Item::Actor(_)
         | ast::Item::Use(_)
-        | ast::Item::ExternBlock(_) => {
+        | ast::Item::ExternBlock(_)
+        | ast::Item::Bitflags(_) => {
             // TODO: Handle these items
         }
     }
@@ -550,6 +551,7 @@ fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> IrOperation {
             receiver,
             method,
             args,
+            ..
         } => {
             let receiver_ir = lower_expr(ctx, receiver);
             let args_ir: Vec<IrOperation> = args.iter().map(|a| lower_expr(ctx, a)).collect();

--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -820,6 +820,9 @@ fn print_item_summary(item: &sigil_parser::Item) {
         Item::ExternBlock(e) => {
             println!("  extern \"{}\" ({} items)", e.abi, e.items.len());
         }
+        Item::Bitflags(b) => {
+            println!("  bitflags {} ({} flags)", b.name.name, b.flags.len());
+        }
     }
 }
 


### PR DESCRIPTION
- Add super::, crate::, self::, Self:: path prefixes in use statements
- Add turbofish ::<Type> syntax support for method calls
- Add Self as valid type identifier in type positions
- Add doc comment support for enum variants and trait items
- Add bitflags macro syntax support (bitflags Name: Type { ... })
- Fix inner attributes to use parse_attr_name for keyword support
- Allow Stream keyword as type identifier for dyn Stream<Item=T>

These changes improve compatibility when parsing Rust-like code with the Sigil parser, addressing common patterns found in Rust codebases.