### PR TITLE
feat(ci): enable wasm + lsp, fix aarch64 — merge develop to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,11 @@ jobs:
 
       - name: Build parser
         working-directory: parser
-        run: cargo build --release --no-default-features --features jit,protocols
+        run: cargo build --release --no-default-features --features jit,wasm,lsp,protocols
 
       - name: Run tests
         working-directory: parser
-        run: cargo test --release --no-default-features --features jit,protocols
+        run: cargo test --release --no-default-features --features jit,wasm,lsp,protocols
         continue-on-error: true
 
       - name: Check formatting
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run clippy
         working-directory: parser
-        run: cargo clippy --no-default-features --features jit,protocols -- -D warnings
+        run: cargo clippy --no-default-features --features jit,wasm,lsp,protocols -- -D warnings
         continue-on-error: true
 
       - name: Test example files
@@ -127,7 +127,7 @@ jobs:
 
       - name: Build release binary
         working-directory: parser
-        run: cargo build --release --no-default-features --features jit,protocols
+        run: cargo build --release --no-default-features --features jit,wasm,lsp,protocols
 
       - name: Create release archive
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build
         working-directory: parser
         run: |
-          FEATURES="--no-default-features --features jit,protocols"
+          FEATURES="--no-default-features --features jit,wasm,lsp,protocols"
           if [ "${{ matrix.cross }}" = "true" ]; then
             cargo install cross --git https://github.com/cross-rs/cross
             cross build --release --target ${{ matrix.target }} $FEATURES

--- a/parser/Cargo.lock
+++ b/parser/Cargo.lock
@@ -2800,6 +2800,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.4+3.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,6 +2816,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -150,7 +150,9 @@ http = { version = "1.1", optional = true }
 http-body-util = { version = "0.1", optional = true }
 
 # WebSocket support (native implementation, TLS via native-tls)
-native-tls = { version = "0.2", optional = true }
+# vendored: builds OpenSSL from source on Linux (needed for aarch64 cross-compile)
+# On Windows (SChannel) and macOS (SecureTransport), vendored is ignored
+native-tls = { version = "0.2", features = ["vendored"], optional = true }
 
 futures-util = { version = "0.3", optional = true }
 


### PR DESCRIPTION
## Summary

Promotes develop to main with:
- WASM and LSP features enabled in release builds
- aarch64 cross-compile fix (vendored native-tls)
- See #44 for details

Tag v0.4.0-rc.3 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)