### PR TITLE
ci(llvm): add LLVM 18 to CI and release pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
           sudo add-apt-repository -y "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main"
           sudo apt-get update
-          sudo apt-get install -y llvm-18-dev
+          sudo apt-get install -y llvm-18-dev libpolly-18-dev
           echo "LLVM_SYS_181_PREFIX=/usr/lib/llvm-18" >> $GITHUB_ENV
 
       - name: Install LLVM 18 (macOS)
@@ -145,7 +145,7 @@ jobs:
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
           sudo add-apt-repository -y "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main"
           sudo apt-get update
-          sudo apt-get install -y llvm-18-dev
+          sudo apt-get install -y llvm-18-dev libpolly-18-dev
           echo "LLVM_SYS_181_PREFIX=/usr/lib/llvm-18" >> $GITHUB_ENV
 
       - name: Build release binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,21 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
+      - name: Install LLVM 18 (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository -y "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main"
+          sudo apt-get update
+          sudo apt-get install -y llvm-18-dev
+          echo "LLVM_SYS_181_PREFIX=/usr/lib/llvm-18" >> $GITHUB_ENV
+
+      - name: Install LLVM 18 (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install llvm@18
+          echo "LLVM_SYS_181_PREFIX=$(brew --prefix llvm@18)" >> $GITHUB_ENV
+
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -42,11 +57,11 @@ jobs:
 
       - name: Build parser
         working-directory: parser
-        run: cargo build --release --no-default-features --features jit,wasm,lsp,protocols
+        run: cargo build --release --no-default-features --features jit,llvm,wasm,lsp,protocols
 
       - name: Run tests
         working-directory: parser
-        run: cargo test --release --no-default-features --features jit,wasm,lsp,protocols
+        run: cargo test --release --no-default-features --features jit,llvm,wasm,lsp,protocols
         continue-on-error: true
 
       - name: Check formatting
@@ -56,7 +71,7 @@ jobs:
 
       - name: Run clippy
         working-directory: parser
-        run: cargo clippy --no-default-features --features jit,wasm,lsp,protocols -- -D warnings
+        run: cargo clippy --no-default-features --features jit,llvm,wasm,lsp,protocols -- -D warnings
         continue-on-error: true
 
       - name: Test example files
@@ -125,9 +140,17 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install LLVM 18
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository -y "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main"
+          sudo apt-get update
+          sudo apt-get install -y llvm-18-dev
+          echo "LLVM_SYS_181_PREFIX=/usr/lib/llvm-18" >> $GITHUB_ENV
+
       - name: Build release binary
         working-directory: parser
-        run: cargo build --release --no-default-features --features jit,wasm,lsp,protocols
+        run: cargo build --release --no-default-features --features jit,llvm,wasm,lsp,protocols
 
       - name: Create release archive
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,27 +21,32 @@ jobs:
             target: x86_64-unknown-linux-gnu
             artifact_name: sigil
             asset_name: sigil-kit-linux-x86_64
+            llvm: true
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact_name: sigil
             asset_name: sigil-kit-linux-aarch64
             cross: true
+            llvm: false
 
           # macOS
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact_name: sigil
             asset_name: sigil-kit-macos-x86_64
+            llvm: true
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact_name: sigil
             asset_name: sigil-kit-macos-aarch64
+            llvm: true
 
           # Windows
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact_name: sigil.exe
             asset_name: sigil-kit-windows-x86_64
+            llvm: true
 
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +55,28 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Install LLVM 18 (Ubuntu)
+        if: matrix.llvm && matrix.os == 'ubuntu-latest'
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository -y "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main"
+          sudo apt-get update
+          sudo apt-get install -y llvm-18-dev
+          echo "LLVM_SYS_181_PREFIX=/usr/lib/llvm-18" >> $GITHUB_ENV
+
+      - name: Install LLVM 18 (macOS)
+        if: matrix.llvm && matrix.os == 'macos-latest'
+        run: |
+          brew install llvm@18
+          echo "LLVM_SYS_181_PREFIX=$(brew --prefix llvm@18)" >> $GITHUB_ENV
+
+      - name: Install LLVM 18 (Windows)
+        if: matrix.llvm && matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          choco install llvm --version=18.1.8 -y
+          echo "LLVM_SYS_181_PREFIX=C:\Program Files\LLVM" >> $env:GITHUB_ENV
 
       - name: Install cross-compilation tools
         if: matrix.cross
@@ -60,7 +87,11 @@ jobs:
       - name: Build
         working-directory: parser
         run: |
-          FEATURES="--no-default-features --features jit,wasm,lsp,protocols"
+          if [ "${{ matrix.llvm }}" = "true" ]; then
+            FEATURES="--no-default-features --features jit,llvm,wasm,lsp,protocols"
+          else
+            FEATURES="--no-default-features --features jit,wasm,lsp,protocols"
+          fi
           if [ "${{ matrix.cross }}" = "true" ]; then
             cargo install cross --git https://github.com/cross-rs/cross
             cross build --release --target ${{ matrix.target }} $FEATURES
@@ -160,10 +191,24 @@ jobs:
             This release includes the complete Sigil Development Kit with:
 
             - **Compiler binary** - Full Sigil compiler with interpreter, JIT, and LLVM backends
+            - **WASM codegen** - Compile Sigil to WebAssembly
+            - **LSP server** - Language server protocol support for editors
+            - **Protocol support** - HTTP client and WebSocket stdlib
             - **Documentation** - Getting started guide, language reference, and standard library docs
             - **Methodologies** - Spec-Driven Development and Agent-TDD guides
             - **Examples** - Progressive example programs
-            - **Style Guide** - Code formatting conventions
+
+            ### Platform Notes
+
+            | Platform | LLVM (`sigil compile`) | JIT (`sigil jit`) | Interpreter (`sigil run`) |
+            |----------|----------------------|-------------------|--------------------------|
+            | Linux x86_64 | yes | yes | yes |
+            | Linux aarch64 | no* | yes | yes |
+            | macOS x86_64 | yes | yes | yes |
+            | macOS aarch64 | yes | yes | yes |
+            | Windows x86_64 | yes | yes | yes |
+
+            *aarch64 Linux: build from source with `cargo install sigil-parser --features llvm` for LLVM support.
 
             ### Quick Install
 
@@ -224,10 +269,15 @@ jobs:
             head "https://github.com/Daemoniorum-LLC/sigil-lang.git", branch: "main"
 
             depends_on "rust" => :build
+            depends_on "llvm@18" => :build
 
             def install
+              ENV["LLVM_SYS_181_PREFIX"] = Formula["llvm@18"].opt_prefix
+
               cd "parser" do
-                system "cargo", "install", *std_cargo_args
+                system "cargo", "install", *std_cargo_args,
+                  "--no-default-features",
+                  "--features", "jit,llvm,wasm,lsp,protocols"
               end
 
               # Install kit documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
           sudo add-apt-repository -y "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main"
           sudo apt-get update
-          sudo apt-get install -y llvm-18-dev
+          sudo apt-get install -y llvm-18-dev libpolly-18-dev
           echo "LLVM_SYS_181_PREFIX=/usr/lib/llvm-18" >> $GITHUB_ENV
 
       - name: Install LLVM 18 (macOS)


### PR DESCRIPTION
## Summary

- Adds LLVM 18 install steps to both CI and release workflows (Ubuntu, macOS, Windows)
- Updates all feature flags from `jit,wasm,lsp,protocols` to `jit,llvm,wasm,lsp,protocols`
- aarch64-linux-gnu excluded from LLVM (can't cross-compile LLVM; ships with JIT + interpreter)
- Updates release notes with platform compatibility table
- Updates Homebrew formula with `llvm@18` dependency

Without this change, release binaries cannot execute `sigil compile` (AOT native compilation).

## Test plan

- [x] CI passes on ubuntu-latest with LLVM 18 (apt.llvm.org)
- [x] CI passes on macos-latest with LLVM 18 (brew)
- [x] Tag rc.4 and verify all 5 release matrix targets build
- [x] Verify Windows LLVM install via choco works

🤖 Generated with [Claude Code](https://claude.com/claude-code)