### PR TITLE
fix(migrate): drop Rust's absolute-path prefix instead of translating it

### DIFF
--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -5157,6 +5157,36 @@ fn migrate_workspace(dry_run: bool, backup: bool, evidentiality: bool) -> ExitCo
 ///
 /// With output_dir, writes to that directory (converting .rs → .sg).
 /// Without output_dir, modifies files in-place.
+/// Drop Rust's absolute-path prefix from `text`, returning the new text and
+/// how many prefixes were removed.
+///
+/// `::gltf::Error` and `::prost::Message` name a path from the crate root.
+/// Sigil has no equivalent, and translating the prefix to `·` yields a leading
+/// middle dot, which does not parse. A `::` that follows an identifier, `>`
+/// (as in `<T as Tr>::Assoc`) or `)` is a real separator and is left alone for
+/// the caller to translate.
+fn drop_absolute_path_prefix(text: &str) -> (String, usize) {
+    let mut out = String::with_capacity(text.len());
+    let mut last = 0;
+    let mut dropped = 0;
+    for (idx, _) in text.match_indices("::") {
+        if idx < last {
+            continue;
+        }
+        let follows_path = text[..idx]
+            .chars()
+            .last()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_' || c == '>' || c == ')');
+        if !follows_path {
+            out.push_str(&text[last..idx]);
+            last = idx + 2;
+            dropped += 1;
+        }
+    }
+    out.push_str(&text[last..]);
+    (out, dropped)
+}
+
 /// Split Rust source into code and non-code regions, applying `f` to the code
 /// only and copying comments and literals through untouched.
 ///
@@ -5472,7 +5502,10 @@ fn migrate_file(path: &str, output_dir: Option<&str>, dry_run: bool, backup: boo
                 }
 
                 // Convert the attribute content
-                // Replace :: with · in attribute names (e.g., tokio::test → tokio·test)
+                // Replace :: with · in attribute names (e.g., tokio::test → tokio·test),
+                // after dropping any absolute-path prefix: `#[derive(::prost::Message)]`
+                // must not render as `·prost·Message`.
+                let (attr_content, _) = drop_absolute_path_prefix(&attr_content);
                 let converted_attr = attr_content.replace("::", "·");
 
                 // Known Sigil rune attributes (convert to //@ rune:)
@@ -5539,6 +5572,10 @@ fn migrate_file(path: &str, output_dir: Option<&str>, dry_run: bool, backup: boo
     // comments above are likewise protected, since they are comments by now.
     result = map_rust_code_spans(&result, |code| {
         let mut piece = code.to_string();
+
+        let (stripped, dropped) = drop_absolute_path_prefix(&piece);
+        piece = stripped;
+        changes += dropped;
 
         for (from, to) in &simple_replacements {
             let count = piece.matches(from).count();
@@ -6561,6 +6598,26 @@ mod migrate_span_tests {
     fn an_identifier_ending_in_b_or_r_is_not_a_literal_prefix() {
         // `sub` and `attr` end in b/r; the following quote opens a real string.
         assert_eq!(mark(r#"sub("for")"#), r#"SUB("for")"#);
+    }
+
+    #[test]
+    fn absolute_path_prefix_is_dropped_not_translated() {
+        // `::gltf::Error` must not keep its leading `::`, which would become a
+        // leading `·` and fail to parse. Inner separators survive.
+        assert_eq!(
+            super::drop_absolute_path_prefix("x(::gltf::Error)").0,
+            "x(gltf::Error)"
+        );
+        // A separator that follows an identifier, `>` or `)` is untouched.
+        assert_eq!(super::drop_absolute_path_prefix("a::b").0, "a::b");
+        assert_eq!(
+            super::drop_absolute_path_prefix("<T as Tr>::Assoc").0,
+            "<T as Tr>::Assoc"
+        );
+        // Every prefix in a list is dropped, and the count is reported.
+        let (out, n) = super::drop_absolute_path_prefix("d(::a::B, ::c::D)");
+        assert_eq!(out, "d(a::B, c::D)");
+        assert_eq!(n, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`::gltf::Error` and `::prost::Message` name a path from the crate root. The migration translated every `::` unconditionally, so the leading one became a leading middle dot — which does not parse.

```
GltfError(#[from] ::gltf::Error),     Rust
GltfError(·gltf·Error),               before  →  expected identifier, found MiddleDot
GltfError(#[from] gltf·Error),        after
```

Sigil has no absolute-path prefix, so the right translation is to drop it rather than render it as `·`.

## The change

Adds `drop_absolute_path_prefix`, which removes a `::` that does **not** follow an identifier, `>` (as in `<T as Tr>::Assoc`) or `)`. Real separators are left for the existing pass to translate.

It's applied in **two** places, because the same unguarded replacement existed twice:

- the **code substitution pass**, where a leading `·` breaks parsing;
- the **attribute conversion**, which did its own `attr_content.replace("::", "·")` and so rendered `#[derive(::prost::Message)]` as `//@ rune: derive(·prost·Message)`. That one lands in a comment rather than breaking the parse, but a rune annotation should still name a valid path.

```
//@ rune: derive(Clone, Copy, PartialEq, ·prost·Message)   before
//@ rune: derive(Clone, Copy, PartialEq, prost·Message)    after
```

## Scope — measured, and narrower than it sounds

Over the Rust engine this was found in: **3 files** contain a leading `::`, across **420 occurrences**, concentrated in generated protobuf code. Both of the corpus's two `found MiddleDot` parse failures come from this.

**The aggregate parse rate over a 400-file sample is unchanged at 285/304**, because none of those three files fall in that sample. This fixes a narrow, real failure; it does not move a headline number, and I'd rather say so than imply otherwise.

| file | before | after |
|---|---|---|
| `aether-asset/src/lib.rs` | parse error at the leading `·` | **parses** |
| `aether-server/src/generated/aether.rs` | MiddleDot error | MiddleDot error gone; blocked further on `r#type`, a raw identifier the lexer doesn't support — separate issue |
| leading `·` in that file's output | 155 | **0** |

## Tests

The existing scanner suite plus one covering this rule directly — that a prefix is dropped, that `a::b` and `<T as Tr>::Assoc` are untouched, and that every prefix in a list is dropped with an accurate count.

```
cargo test --release --no-default-features --features jit,native --bin sigil
#   13 passed; 0 failed
```

Build verified with `--no-default-features --features jit,native`; LLVM 18 isn't available in this environment, so the `llvm` feature build is left to CI, which installs it.

## Context — most remaining failures are not migration bugs

This came out of parsing the aether Sigil corpus (852 `.sg` files, 88% parsing against current `develop`). Of the 96 failures, the two largest categories are **language gaps rather than tool bugs**, and I'm raising them here rather than working around them in the migration:

- **`☉(crate)` — 22 files.** `docs/RUST-TO-SIGIL-MIGRATION.md` documents `pub(crate)` → `☉(crate)`, but the parser rejects it (`expected identifier, found LParen`). The tool emits exactly what the guide specifies; restricted visibility appears unimplemented.
- **Keyword collisions — 21 files.** `aspect` is a prose alias for `trait` and `of` for `∈`, so `aspect: f32` and `TypeId::of::<T>()` are both syntax errors. The wider surface is large — counting identifier sites in that Rust engine against the 89 ASCII keywords: `location` 247, `body` 164, `from` 101, `to` 91, `atomic` 91, `of` 57, `layer` 50, `trigger` 42, `header` 25, `aspect` 23.

Having the migration silently rename user identifiers would hide that rather than fix it, so it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBMCTye5QEFfyXabxvKYrE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBMCTye5QEFfyXabxvKYrE)_