### PR TITLE
fix(migrate): translate Rust's `crate` to Sigil's `tome`

### DIFF
--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -5401,6 +5401,12 @@ fn migrate_file(path: &str, output_dir: Option<&str>, dry_run: bool, backup: boo
         ("return", "⤺", &[" ", ";", "(", ","]),
         ("break", "⊗", &[";", " ", ","]),
         ("continue", "↻", &[";", " ", ","]),
+        // `crate` is a Rust word with no Sigil equivalent — Sigil's term for a
+        // compilation unit is `tome`. Left alone it still parses, because
+        // `crate` is not a Sigil keyword and so reads as a module literally
+        // named "crate": silently wrong rather than loudly wrong. Runs after
+        // the `::` pass above, so the separator is already `·`.
+        ("crate", "tome", &["·", ")"]),
     ];
 
     let mut result = source.clone();
@@ -6561,6 +6567,24 @@ mod migrate_span_tests {
     fn an_identifier_ending_in_b_or_r_is_not_a_literal_prefix() {
         // `sub` and `attr` end in b/r; the following quote opens a real string.
         assert_eq!(mark(r#"sub("for")"#), r#"SUB("for")"#);
+    }
+
+    #[test]
+    fn the_word_crate_survives_in_prose() {
+        // `crate` -> `tome` is a code substitution. "this crate provides..."
+        // is one of the commonest phrases in Rust documentation, and a doc
+        // comment that reads "this tome provides" would be nonsense. The
+        // scanner is what keeps the two apart, so pin it here.
+        let src = "//! This crate provides maths.\nlet x = crate::E;";
+        let out = map_rust_code_spans(src, |c| c.replace("crate", "tome"));
+        assert_eq!(out, "//! This crate provides maths.\nlet x = tome::E;");
+
+        let s2 = "let m = \"this crate is not a tome\"; let y = crate::F;";
+        let o2 = map_rust_code_spans(s2, |c| c.replace("crate", "tome"));
+        assert_eq!(
+            o2,
+            "let m = \"this crate is not a tome\"; let y = tome::F;"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`crate` is a Rust word. Sigil's term for a compilation unit is `tome`, and **`crate` is not a Sigil token at all** — so a migrated path doesn't mean what it looks like it means:

```
invoke crate·state·{EditorTool, TransformSpace};    before — parses, means the wrong thing
invoke tome·state·{EditorTool, TransformSpace};     after
```

Because `crate` isn't a keyword, the parser reads it as a module *literally named* `crate`. That's why these paths have never shown up as parse errors: **they parse cleanly and are silently wrong**, which is worse than failing loudly.

## The change

One entry in the keyword table:

```rust
("crate", "tome", &["·", ")"]),
```

It runs after the `::` pass, so the separator is already `·`. The existing word-boundary check keeps identifiers that merely end in the word intact — `mycrate::q` stays `mycrate·q`, verified.

## Scope

| | |
|---|---|
| committed aether corpus | **1,167 sites across 357 of 852 files** |
| 400-file migration of the current Rust engine | 230 sites → **0 `crate·` remaining** |
| parse rate | 285/304 → **285/304, unchanged** |

**The unchanged parse rate is the point, not a disappointment.** The old output already parsed. This replaces incorrect output with correct output; it doesn't move a failure count, and I'd rather say that than dress it up.

## `pub(crate)`

The `)` suffix also rewrites `pub(crate)` → `☉(tome)`. **That still doesn't parse**, and it's worth being explicit about why:

- `parse_visibility` handles only `☉` and private.
- `Visibility::Crate` and `Visibility::Super` exist in the AST but are **unreachable** — no surface syntax constructs them, in any spelling.

I tested `☉(tome)`, `☉(super)` and `☉(crate)` — all three are rejected identically, so this isn't a word problem, it's an unimplemented feature. Emitting the Sigil word leaves the parser gap as the single remaining blocker there rather than compounding it with a Rust one.

`docs/RUST-TO-SIGIL-MIGRATION.md` documents `pub(crate)` → `☉(crate)`, which is wrong on both counts — unimplemented syntax, and a word the language doesn't have. It wants updating alongside whatever the parser grows.

## Tests

A test pins the interaction with the comment and literal scanner added in #63. `"this crate provides..."` is one of the commonest phrases in Rust documentation, and a doc comment reading *"this tome provides"* would be nonsense:

```
//! This crate provides vector maths.          ← preserved
/// Re-exported from crate::core.              ← preserved
let msg = "this crate is not a tome";          ← preserved
let _ = crate::EPSILON;   →  ≔ _ = tome·EPSILON;   ← translated
```

That scanner is load-bearing for this change; without it every prose mention of "crate" would be rewritten.

```
cargo test --release --no-default-features --features jit,native --bin sigil
#   13 passed; 0 failed
```

Build verified with `--features jit,native`; LLVM 18 isn't available here, so the `llvm` build is left to CI, which installs it and passed that configuration on #63.

## Related

Independent of #64 (absolute-path prefix), which touches the same function but a different rule. Either can merge first.

Both come out of a survey of Rustisms surviving migration into the aether corpus. What's left, for reference:

| construct | sites | files | |
|---|---|---|---|
| `std·` / `core·` / `alloc·` | 2,692 | ~600 | Rust stdlib names; needs a Sigil stdlib mapping |
| `r#type` | 128 | 60 | raw identifiers, exist only to escape Rust keywords |
| `for<'de>` | 3 | 3 | higher-ranked trait bounds |

`Self`, `as`, `dyn`, `unsafe` and `static` are all Sigil tokens already and are not Rustisms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBMCTye5QEFfyXabxvKYrE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBMCTye5QEFfyXabxvKYrE)_