### PR TITLE
fix(migrate): rewrite Rust's `core` and `alloc` onto Sigil's `std`

### DIFF
--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -5187,6 +5187,74 @@ fn drop_absolute_path_prefix(text: &str) -> (String, usize) {
     (out, dropped)
 }
 
+/// Rewrite `from` to `to` where `from` begins a path, returning the new text
+/// and how many roots were rewritten.
+///
+/// "Begins a path" means the preceding character is neither an identifier
+/// character nor `·`. That second exclusion is what keeps `std·alloc·Layout`
+/// intact while rewriting a bare `alloc·Layout`: `std::alloc` is a real `std`
+/// path, and rewriting its second segment would produce `std·std·Layout`.
+fn rewrite_path_root(text: &str, from: &str, to: &str) -> (String, usize) {
+    let mut out = String::with_capacity(text.len());
+    let mut last = 0;
+    let mut rewritten = 0;
+    for (idx, _) in text.match_indices(from) {
+        if idx < last {
+            continue;
+        }
+        let at_root = text[..idx]
+            .chars()
+            .last()
+            .is_none_or(|c| !(c.is_alphanumeric() || c == '_' || c == '·'));
+        if at_root {
+            out.push_str(&text[last..idx]);
+            out.push_str(to);
+            last = idx + from.len();
+            rewritten += 1;
+        }
+    }
+    out.push_str(&text[last..]);
+    (out, rewritten)
+}
+
+/// Collapse a qualified path ending in `suffix` to `to`, dropping any crate
+/// qualifier in front of it. Returns the new text and how many were collapsed.
+///
+/// Generated code rarely names the no_std prelude paths directly: prost emits
+/// `::prost::alloc::string::String`, its own re-export for no_std builds. That
+/// is the same `String`, so the qualifier is noise once the path is no longer
+/// Rust's.
+fn collapse_qualified_path(text: &str, suffix: &str, to: &str) -> (String, usize) {
+    let mut out = String::with_capacity(text.len());
+    let mut last = 0;
+    let mut collapsed = 0;
+    for (idx, _) in text.match_indices(suffix) {
+        if idx < last {
+            continue;
+        }
+        // Walk back over any `ident·` segments qualifying this path.
+        let mut start = idx;
+        loop {
+            let head = &text[last..start];
+            let Some(before_dot) = head.strip_suffix('·') else {
+                break;
+            };
+            let trimmed = before_dot.trim_end_matches(|c: char| c.is_alphanumeric() || c == '_');
+            if trimmed.len() == before_dot.len() {
+                // A `·` with no identifier in front of it is not a qualifier.
+                break;
+            }
+            start = last + trimmed.len();
+        }
+        out.push_str(&text[last..start]);
+        out.push_str(to);
+        last = idx + suffix.len();
+        collapsed += 1;
+    }
+    out.push_str(&text[last..]);
+    (out, collapsed)
+}
+
 /// Split Rust source into code and non-code regions, applying `f` to the code
 /// only and copying comments and literals through untouched.
 ///
@@ -5589,6 +5657,33 @@ fn migrate_file(path: &str, output_dir: Option<&str>, dry_run: bool, backup: boo
                 changes += count;
                 piece = piece.replace(from, to);
             }
+        }
+
+        // `core` and `alloc` are Rust's no_std subsets of `std`. Sigil
+        // registers neither, so a migrated `core·option·Option` names a module
+        // that does not exist — it parses, and resolves to nothing. Everything
+        // those two expose is re-exported from `std`, so rewrite the root onto
+        // it. The three prelude types that dominate generated protobuf output
+        // collapse to the bare names a Sigil programmer would write.
+        // The three prelude types collapse to their bare names wherever they
+        // appear, qualifier and all: prost writes
+        // `::prost::alloc::string::String`, which is still just `String`.
+        for (suffix, to) in [
+            ("core·option·Option", "Option"),
+            ("alloc·string·String", "String"),
+            ("alloc·vec·Vec", "Vec"),
+        ] {
+            let (collapsed, count) = collapse_qualified_path(&piece, suffix, to);
+            piece = collapsed;
+            changes += count;
+        }
+
+        // Anything else under those roots moves onto `std`, but only at a path
+        // root: `std·alloc·Layout` is a real std path.
+        for (from, to) in [("core·", "std·"), ("alloc·", "std·")] {
+            let (rewritten, count) = rewrite_path_root(&piece, from, to);
+            piece = rewritten;
+            changes += count;
         }
 
         for (keyword, replacement, suffixes) in keyword_replacements {
@@ -6642,6 +6737,40 @@ mod migrate_span_tests {
         let (out, n) = super::drop_absolute_path_prefix("d(::a::B, ::c::D)");
         assert_eq!(out, "d(a::B, c::D)");
         assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn no_std_roots_are_rewritten_onto_std() {
+        let f = |t: &str| {
+            let mut s = t.to_string();
+            for (suffix, to) in [
+                ("core·option·Option", "Option"),
+                ("alloc·string·String", "String"),
+                ("alloc·vec·Vec", "Vec"),
+            ] {
+                s = super::collapse_qualified_path(&s, suffix, to).0;
+            }
+            for (from, to) in [("core·", "std·"), ("alloc·", "std·")] {
+                s = super::rewrite_path_root(&s, from, to).0;
+            }
+            s
+        };
+        // Prelude types collapse to bare names.
+        assert_eq!(f("a: core·option·Option<u32>"), "a: Option<u32>");
+        assert_eq!(f("b: alloc·string·String"), "b: String");
+        assert_eq!(f("c: alloc·vec·Vec<u8>"), "c: Vec<u8>");
+        // Including through a crate's own no_std re-export, as prost emits.
+        assert_eq!(f("d: prost·alloc·string·String"), "d: String");
+        assert_eq!(f("e: prost·alloc·vec·Vec<u8>"), "e: Vec<u8>");
+        assert_eq!(f("f: core·option·Option<prost·alloc·string·String>"), "f: Option<String>");
+        // Anything else moves onto std.
+        assert_eq!(f("core·sync·atomic·Ordering"), "std·sync·atomic·Ordering");
+        // `std::alloc` is a real std path and must survive untouched — the
+        // reason the root guard excludes a preceding `·`.
+        assert_eq!(f("std·alloc·Layout"), "std·alloc·Layout");
+        assert_eq!(f("invoke std·alloc·{alloc, dealloc}"), "invoke std·alloc·{alloc, dealloc}");
+        // An identifier that merely ends in the root is not a root.
+        assert_eq!(f("mycore·x"), "mycore·x");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`core` and `alloc` are Rust's no_std subsets of `std`. **Sigil registers neither** — but it does register `std`, so the three are not equivalent cases:

| root | Sigil registrations |
|---|---|
| `std·` | **31** — `std·fs·read_to_string`, `std·process·exit`, `std·thread·spawn`, … |
| `core·` | 0 |
| `alloc·` | 0 |

Sigil's own ecosystem libraries import `std·collections·`, `std·time·`, `std·sync·`, `std·cmp·`. So `std::` → `std·` was always correct. `core::` and `alloc::` migrate to module roots that don't exist — they parse, and resolve to nothing.

> Correcting my own earlier report: I previously listed `std·`/`core·`/`alloc·` together as ~2,692 sites needing a Sigil stdlib mapping. That was wrong — `std·` is native. The genuinely broken set is 263 sites.

## Two rules

**Prelude types collapse to bare names** — what a Sigil programmer writes, and what Sigil's prelude provides:

```
core·option·Option   →  Option
alloc·string·String  →  String
alloc·vec·Vec        →  Vec
```

The collapse also drops a qualifier in front of the path. Generated code rarely names these directly: prost emits `::prost::alloc::string::String`, its own re-export for no_std builds. **The aether corpus contains no bare `alloc::string::String` at all** — all 160 sites are prost-qualified — so a root-anchored rule would have missed every one of them. I found this only by checking the output rather than trusting the first implementation.

**Everything else moves onto `std`, but only at a path root:**

```
core·sync·atomic·Ordering  →  std·sync·atomic·Ordering
std·alloc·Layout           →  std·alloc·Layout      (unchanged)
```

That second case is the reason `rewrite_path_root` excludes a preceding `·` as well as identifier characters. `std::alloc` is a real `std` path — the engine imports `std::alloc::{alloc, dealloc, Layout}` — and rewriting its second segment would produce `std·std·Layout`. There's a test pinning it.

## Verified end to end

Every merged migration fix, exercised together on one file:

```
//! This crate provides maths for the std::fmt case, in a loop.   ← prose intact
invoke tome·state·Editor;                                          ← #65
☉ Σ S {
    ☉ name: String,                       ← ::prost::alloc::string::String
    ☉ pos: Option<Vec3>,                  ← ::core::option::Option
    ☉ tags: Vec<u8>,                      ← ::prost::alloc::vec::Vec
    ☉ ord: std·sync·atomic·Ordering,      ← core::sync::atomic::Ordering
}
☉ rite f() -> Result<(), gltf·Error> {    ← #64, no leading ·
    ≔ msg = "this crate is not a tome";   ← literal intact
    invoke std·alloc·{alloc, Layout};     ← not std·std
    Ok(())
}
```

Parses successfully. On the real generated protobuf module: **zero `core·`/`alloc·` remaining**.

```
cargo test --release --no-default-features --features jit,native --bin sigil
#   15 passed; 0 failed
```

rustfmt-clean (0 diffs touch the new code). Build verified with `--features jit,native`; LLVM 18 isn't available here, so that configuration is left to CI, which has passed it on #63, #64 and #65.

## Notes

Rebased onto `develop` after #64 and #65 merged; no conflicts. Branched from `develop` and targets `develop` per `CLAUDE.md`.

Remaining Rustisms in the corpus after this, for reference:

| construct | sites | files | |
|---|---|---|---|
| `r#type` | 128 | 60 | raw identifiers; exist only to escape Rust keywords, so each needs a real rename |
| `for<'de>` | 3 | 3 | higher-ranked trait bounds |

Separately, and not a migration matter: Sigil reserves 89 ASCII words as keywords, including prose aliases like `aspect` (= `trait`) and `of` (= `∈`). Those collide with ordinary identifiers — `aspect` alone breaks 14 corpus files, `of` breaks 7 via `TypeId::of::<T>()` — and `location` (247), `body` (164), `from` (101) and `to` (91) are waiting behind them. That's a language design question, not something the migration should paper over by renaming user code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBMCTye5QEFfyXabxvKYrE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBMCTye5QEFfyXabxvKYrE)_