### PR TITLE
ci: enforce that PRs to main come from develop

### DIFF
--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -1,0 +1,51 @@
+# Enforces the branch strategy in CLAUDE.md:
+#
+#   main    - production releases only
+#   develop - staging; all feature work merges here first
+#
+# This exists because the strategy stopped holding. #59 and #61 went straight to
+# `main`, which left `main` and `develop` diverged by 8 commits each and parsing
+# the ecosystem differently -- `main` regressed nihil from 104/104 to 83/104 while
+# fixing morgoth from 50/259 to 257/259, so neither branch was correct and each
+# held work the other lacked. Reconciling that is a 97-hunk merge.
+#
+# A convention that is only written down is one that drifts. This makes it fail.
+name: Branch Policy
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  base-branch:
+    name: PRs to main come from develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the head branch
+        env:
+          # Passed through the environment rather than interpolated into the
+          # script: a branch name is attacker-controlled text, and `${{ }}` inside
+          # a run block substitutes before the shell sees it.
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          case "$HEAD_REF" in
+            develop|release/*|hotfix/*)
+              echo "OK: $HEAD_REF -> main"
+              exit 0
+              ;;
+          esac
+
+          echo "::error title=Wrong base branch::PRs to main must come from develop, release/* or hotfix/*. This one is from '$HEAD_REF'."
+          cat <<'EOF'
+
+          main is for production releases only. Feature work targets develop and
+          reaches main through a release merge -- see the Git Workflow section of
+          CLAUDE.md.
+
+          To fix: change this PR's base branch to develop. No push is needed;
+          GitHub keeps the commits.
+
+          If this genuinely is a release or a hotfix, name the branch release/<x>
+          or hotfix/<x> and the check will pass.
+          EOF
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,24 @@ git checkout -b feature/my-feature
 - Target `develop` for all feature work
 - Target `main` only for release PRs from `develop`
 
+This is enforced by `.github/workflows/branch-policy.yml`: a PR to `main` whose head
+is not `develop`, `release/*` or `hotfix/*` fails. Changing the base branch on an
+existing PR is enough to fix it -- GitHub keeps the commits, no push required.
+
+**Why it is enforced rather than documented.** The convention lapsed: #59 and #61
+merged straight to `main`, leaving `main` and `develop` diverged by 8 commits each
+and parsing the ecosystem differently. Measured on files passing `sigil check`:
+
+| Repository | merge base | `main` | `develop` |
+|---|---:|---:|---:|
+| `nihil` | 104/104 | **83/104** | 104/104 |
+| `morgoth` | 50/259 | **257/259** | 42/259 |
+| `lucifer` | 18/26 | 21/26 | 18/26 |
+
+Neither branch was correct and each held work the other lacked -- `main` regressed
+nihil while fixing morgoth. Reconciling them is a 97-hunk merge across 17 files.
+That is the cost of the rule not holding.
+
 ## Development Workflow
 
 1. **Branch from develop**: `git checkout develop && git checkout -b feature/my-feature`


### PR DESCRIPTION
## Why

`CLAUDE.md` says `main` is production releases only and all feature work merges to `develop` first. That stopped holding — and it is still not holding: of the four PRs open right now, **two target `main` from feature branches** (#62 and #66; #66 is mine).

Historically, #59 and #61 merged straight to `main`. The cost is measurable. `main` and `develop` are now diverged by 8 commits each, and they parse the ecosystem differently. Files passing `sigil check`:

| Repository | merge base | `main` | `develop` |
|---|---:|---:|---:|
| `nihil` | 104/104 | **83/104** | 104/104 |
| `morgoth` | 50/259 | **257/259** | 42/259 |
| `lucifer` | 18/26 | 21/26 | 18/26 |

`main` regressed nihil (in #61) while fixing morgoth. So neither branch is correct, and each holds work the other lacks. Reconciling them is a **97-hunk merge across 17 files**, most of it in `llvm_codegen.rs` (44) and `interpreter.rs` (20). That is the bill for the rule not holding.

## What this does

Fails a PR to `main` whose head branch is not `develop`, `release/*` or `hotfix/*`, and says in the failure how to fix it:

```
Error: PRs to main must come from develop, release/* or hotfix/*.
       This one is from 'feature/foo'.

To fix: change this PR's base branch to develop. No push is needed;
GitHub keeps the commits.
```

Changing a base branch is a dropdown on the PR — no force-push, no lost review history — so the check is cheap to satisfy when it fires legitimately, and `release/*` / `hotfix/*` leave the real escape hatches open.

`CLAUDE.md` gains the enforcement note and the table above, so the rule travels with its own reason rather than being a bare assertion.

## One implementation note

The head ref reaches the script through `env:` rather than `${{ }}` interpolation:

```yaml
env:
  HEAD_REF: ${{ github.head_ref }}
run: |
  case "$HEAD_REF" in ...
```

A branch name is attacker-controlled text, and `${{ }}` inside a `run` block substitutes *before* the shell parses the line — so the interpolated form is a script-injection vector on any workflow that a fork can trigger.

## Note

This check would fail **#66 and #62 as they currently stand**. That is the intent, not an oversight. Both should be retargeted to `develop`; for #66 that is the right home anyway, since the regression it fixes exists only on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsfG6C1ZdnNUscmcfrChVz

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsfG6C1ZdnNUscmcfrChVz)_