### PR TITLE
fix(llvm): compile an index expression once, not twice

### DIFF
--- a/parser/src/llvm_codegen.rs
+++ b/parser/src/llvm_codegen.rs
@@ -11511,7 +11511,6 @@ pub mod llvm {
             expr: &Expr,
             index: &Expr,
         ) -> Result<IntValue<'ctx>, String> {
-            let idx = self.compile_expr(fn_value, scope, index)?;
             let i64_type = self.context.i64_type();
             let ptr_type = self.context.ptr_type(AddressSpace::default());
 
@@ -19023,13 +19022,6 @@ pub mod llvm {
                 OptLevel::Aggressive => "default<O2>",
             };
             eprintln!("[DEBUG] run_llvm_optimizations: running passes {}", passes);
-
-            // Configure pass builder with explicit vectorization options
-            let pass_options = PassBuilderOptions::create();
-            pass_options.set_loop_vectorization(true);
-            pass_options.set_loop_slp_vectorization(true);
-            pass_options.set_loop_interleaving(true);
-            pass_options.set_loop_unrolling(true);
 
             // Configure pass builder with explicit vectorization options
             let pass_options = PassBuilderOptions::create();


### PR DESCRIPTION
Two defects in `llvm_codegen.rs`, both found while resolving #62 against `develop`.

## 1. `compile_index` compiled the index expression twice

```rust
) -> Result<IntValue<'ctx>, String> {
    let idx = self.compile_expr(fn_value, scope, index)?;   // ← 11514
    let i64_type = self.context.i64_type();
    ...
    if let Expr::Range { .. } = index {
        return self.compile_range_index(...);               // ← early return, never uses idx
    }

    let idx = self.compile_expr(fn_value, scope, index)?;   // ← 11523, identical, shadows it
```

The second binding shadows the first, so the first is pure waste — except it sits **above** the `Expr::Range` early return, so it also runs on the slice path that discards it.

For a side-effecting index this is a **correctness bug**, not just dead codegen: `arr[next()]` emitted the call to `next()` twice.

## 2. Duplicated `PassBuilderOptions` block

In `run_llvm_optimizations`, a `PassBuilderOptions` was created and configured with four `set_loop_*` calls, then an identical block immediately followed and shadowed it. The first was constructed and dropped.

## Why fix it here rather than in #62

Both appear as conflicts when a branch merges `develop`. Fixing them on `develop` directly stops the conflict recurring — otherwise the next resolver sees a hoisted binding with no way to tell whether it was deliberate, and may well restore it. #62's resolution removed them locally; this makes that unnecessary.

## Verification

No regression, measured both ways:

```
unmodified develop:  540 passed / 3 failed
with this fix:       540 passed / 3 failed
```

Same three pre-existing failures in both: `test_generic_struct_basic`, `test_generic_struct_two_params`, `test_parse_actor`. Built with default features (LLVM 18), so this file is genuinely compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X791QDdm9Y6F3fAoLFrQ5e