### PR TITLE
fix(parser): a module root is lowercase, and so is a receiver

### DIFF
--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -26543,13 +26543,13 @@ mod tests {
     fn impl_inside_a_module_keeps_its_associated_consts() {
         // Module impls registered their methods but dropped every const, so
         // `P·ONE` was not merely wrong but absent: reading `.x` off it yielded
-        // null rather than 1.0. (Still the behaviour on develop today.)
+        // null rather than 1.0.
         //
-        // The const is asserted through the unqualified `P·ONE` alias rather
-        // than `geom·P·ONE` because module-qualified path resolution is
-        // currently broken on develop for *everything* — `geom·P·new(..)`, an
-        // ordinary static method that predates this branch, fails the same way.
-        // See `module_qualified_paths_are_unresolvable`.
+        // Asserted through the module-qualified `geom·P·ONE`, which is how the
+        // const is actually spelled from outside the scroll. #75 had to route
+        // this through the unqualified `P·ONE` alias, because the qualified
+        // form could not be parsed at all; see
+        // `module_qualified_paths_resolve`. Both spellings are pinned here.
         let source = "\
             scroll geom {
                 ☉ Σ P { ☉ x: f32 }
@@ -26558,19 +26558,16 @@ mod tests {
                     ☉ rite new(x: f32) -> Self { Self { x } }
                 }
             }
-            rite main() { ⤺ P·ONE.x; }";
-        assert!(matches!(run(source), Ok(Value::Float(v)) if v == 1.0));
+            rite main() { ⤺ geom·P·ONE.x + P·ONE.x; }";
+        assert!(matches!(run(source), Ok(Value::Float(v)) if v == 2.0));
     }
 
     #[test]
-    #[ignore = "pre-existing develop regression, unrelated to operator dispatch"]
-    fn module_qualified_paths_are_unresolvable() {
-        // Regression record, not a claim about this branch. `module·Type·member`
-        // resolves on the merge base and fails on develop with
-        // "undefined variable: `geom`" — for a plain static method, with no
-        // consts and no operator traits involved. Whatever landed in develop
-        // between 7adc3af and 42ee1f0 broke it; fixing that belongs in its own
-        // change. Un-ignore this test when it is fixed.
+    fn module_qualified_paths_resolve() {
+        // `module·Type·member` used to fail with "undefined variable: `geom`":
+        // `parse_type_path` stopped at the first `·` after a lowercase segment,
+        // so the path became a field access on a variable that was never bound.
+        // A plain static method, no consts and no operator traits involved.
         let source = "\
             scroll geom {
                 ☉ Σ P { ☉ x: f32 }
@@ -26578,6 +26575,29 @@ mod tests {
             }
             rite main() { ⤺ geom·P·new(3.0).x; }";
         assert!(matches!(run(source), Ok(Value::Float(v)) if v == 3.0));
+    }
+
+    #[test]
+    fn a_lowercase_receiver_is_still_a_method_call_not_a_path() {
+        // The other half of the same decision, and the reason the qualified
+        // form was broken in the first place: #61 stopped `·` from being
+        // consumed as a path separator after a lowercase segment, because
+        // `tag·to_string()` was being parsed as a call to a path `tag·to_string`
+        // and dispatched to a built-in of the wrong arity. Nothing in the chain
+        // names a type, so it must stay a method call on `tag`.
+        let source = "\
+            scroll geom {
+                ☉ Σ P { ☉ x: f32 }
+                ⊢ P {
+                    ☉ rite new(x: f32) -> Self { Self { x } }
+                    ☉ rite scaled(self, k: f32) -> f32 { self.x * k }
+                }
+            }
+            rite main() {
+                ≔ p = geom·P·new(3.0);
+                ⤺ p·scaled(2.0);
+            }";
+        assert!(matches!(run(source), Ok(Value::Float(v)) if v == 6.0));
     }
 
     #[test]

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -4220,14 +4220,33 @@ impl<'a> Parser<'a> {
                 .map(|s| s.ident.name.chars().next().map_or(false, |c| c.is_uppercase()))
                 .unwrap_or(false);
 
+        // Once a `·` has been accepted as a path separator, every following `·` in
+        // the same chain is one too: `geom·P·new` is one path, not a path `geom·P`
+        // with a method call hung off it.
+        let mut middledot_is_path_sep = in_type_context || first_segment_is_type;
+
         while !self.pending_gt.is_some() {
             // Only allow · as a path separator for type paths (uppercase first letter).
             // For lowercase identifiers (variables), · is a method-call operator and
             // must be left for postfix expression parsing (parse_postfix_expr MiddleDot arm).
             // In a type position `·` is always a separator; elsewhere fall back to the
             // uppercase heuristic that keeps method calls out of path parsing.
-            let is_path_sep =
-                (in_type_context || first_segment_is_type) && self.consume_if(&Token::MiddleDot);
+            //
+            // The heuristic alone cannot see a MODULE root: `geom` in `geom·P·new(…)`
+            // is lowercase for the same reason `tag` is in `tag·to_string()`, and
+            // stopping at the first `·` turns the path into a field access on a
+            // variable that was never bound — "undefined variable: `geom`" (#86).
+            // What separates them is what the chain leads TO: a module chain reaches
+            // a segment naming a type, because Sigil types are uppercase and methods
+            // are not. `geom·P·new` reaches `P`; `tag·to_string` reaches nothing.
+            if !middledot_is_path_sep
+                && self.check(&Token::MiddleDot)
+                && self.middledot_chain_reaches_a_type()
+            {
+                middledot_is_path_sep = true;
+            }
+
+            let is_path_sep = middledot_is_path_sep && self.consume_if(&Token::MiddleDot);
             if !is_path_sep {
                 break;
             }
@@ -4253,6 +4272,37 @@ impl<'a> Parser<'a> {
         }
 
         Ok(TypePath { segments })
+    }
+
+    /// With the current token on a `·`, does the chain of `·ident` that follows
+    /// reach a segment that names a TYPE?
+    ///
+    /// This is the only thing that tells a module root apart from a receiver in
+    /// expression position, where both are lowercase. `geom·P·new(…)` reaches `P`
+    /// and is a path; `tag·to_string()` reaches nothing uppercase and is a method
+    /// call on `tag`. The scan stops at the first token that is not part of a
+    /// `·ident` chain, so a call, an index or an operator ends it — `xs·map(f)`
+    /// never looks past the `(`.
+    fn middledot_chain_reaches_a_type(&mut self) -> bool {
+        // peek_n(0) is the token after the current `·`.
+        let mut n = 0usize;
+        // A path this long is not a path; bail rather than scan an entire file.
+        while n < 32 {
+            let names_a_type = match self.peek_n(n) {
+                Some(Token::Ident(name)) => {
+                    name.chars().next().is_some_and(|c| c.is_uppercase())
+                }
+                _ => return false,
+            };
+            if names_a_type {
+                return true;
+            }
+            if !matches!(self.peek_n(n + 1), Some(Token::MiddleDot)) {
+                return false;
+            }
+            n += 2;
+        }
+        false
     }
 
     fn parse_path_segment(&mut self) -> ParseResult<PathSegment> {


### PR DESCRIPTION
## What

`geom·P·new(3.0)` failed at runtime with ``undefined variable: `geom` `` while `P·new(3.0)` returned 3 — the type and the static method both resolved, and only the `module·` qualifier did not.

It is a **parse** defect, not an interpreter one. `dump-ir` says so outright:

| | |
|---|---|
| working | `call geom::P::new` |
| broken | method call `new` on field `P` of a variable `geom` that was never bound |

## Which commit, and what it actually did

**`8f92d5c` (#61)** — bisected over 131 commits, `01f4d6a` good. That is *much older* than the range #86 proposed, and none of the three candidates (`c7e003d`, `7580314`, `2a0a2ef`) touch path resolution at all; their `interpreter.rs` hunks are `to_bool`, `Set::contains_key` and `String::slice`/`find`. `8f92d5c` predates #62's branch and reached develop only when that branch merged — which is why develop's own tip at `7adc3af` still worked. The issue's "works at `7adc3af`" claim is correct, but it worked *by accident*:

```rust
let is_path_sep = self.consume_if(&Token::MiddleDot)
    || (first_segment_is_type && self.consume_if(&Token::MiddleDot));
```

The first operand always fires, so `first_segment_is_type` never decided anything and every `·` was swallowed as a path separator. #61 fixed a real bug with that — `tag·to_string()` was parsed as a call to a path `tag·to_string` and dispatched to a built-in of the wrong arity — by making the guard load-bearing:

```rust
let is_path_sep = first_segment_is_type && self.consume_if(&Token::MiddleDot);
```

Correct for a receiver, wrong for a module. Both are lowercase, and `first_segment_is_type` cannot tell them apart, so the fix took module-qualified paths down with the misparse. `8e4e326` recorded the survivor as a follow-up — *"`std·collections·HashMap·new()` still fails at runtime with undefined variable: std … it cannot be fixed by enumerating keywords, since any module name may be lowercase"* — and added `tome`/`super` as keyword roots, which covers the two spellings that are keywords and none of the ones that are not.

## The fix

What separates a module root from a receiver is not the root but what the chain leads **to**. A module chain reaches a segment naming a type, because Sigil types are uppercase and methods are not: `geom·P·new` reaches `P`; `tag·to_string` reaches nothing.

So in expression position `·` is a path separator when the `·ident` chain ahead of it reaches an uppercase segment, and once one `·` is accepted the rest of the chain is a path too. The scan stops at the first token that is not `·ident`, so a call, an index or an operator ends it — `xs·map(f)` never looks past the `(`.

Both halves of #61's decision stay true, and the follow-up `8e4e326` recorded falls out as the same rule one segment further along:

```sigil
geom·P·new(3.0).x        → 3     (was: undefined variable: `geom`)
outer·inner·Q·new(7).n   → 7     (was: undefined variable: `outer`)
P·new(3.0).x             → 3     (unchanged)
tag·to_string()          → method call on `tag`   (unchanged)
xs·len(), m·get(k)       → unchanged
```

**The interpreter is untouched.** It has registered `geom·P·new` all along; nothing ever asked it for that name.

## Tests

- `module_qualified_paths_are_unresolvable` was the `#[ignore]`d record of this bug. Un-ignored and renamed `module_qualified_paths_resolve`.
- `a_lowercase_receiver_is_still_a_method_call_not_a_path` pins the other half, so the next person to touch this line has both cases in front of them. #61's own `test_middledot_method_dispatch` still passes.
- `impl_inside_a_module_keeps_its_associated_consts` asserted through the unqualified `P·ONE` alias because #75 could not spell the qualified form. That workaround is gone; it now asserts `geom·P·ONE.x + P·ONE.x`, pinning both.

## Verification

Measured on this machine rather than quoted, baseline taken at `2e6aac6`:

| | baseline | this PR |
|---|---|---|
| lib | 557 pass / 2 fail / 1 ignored | **559 pass / 2 fail / 0 ignored** |
| bins | 25 / 25 | 25 / 25 |
| Sigil suite | 794 pass / 4 fail / 2 skip | 794 pass / 4 fail / 2 skip |

The same two lib failures on both sides — `test_generic_struct_basic` and `test_generic_struct_two_params`, both pre-existing LLVM generic-struct, neither touched here. Sigil-suite per-test results are byte-identical between the two runs.

`sigil check`, `jit` and `llvm` on the reproduction behave exactly as they do on `develop` (the LLVM backend returns a garbage f32 on both sides, and on `7adc3af` too — separate, pre-existing, not this).

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X791QDdm9Y6F3fAoLFrQ5e
