### PR TITLE
fix(cli): shape the main call to its declared arity, and say tome not crate

### DIFF
--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -19773,6 +19773,25 @@ impl Interpreter {
         }
     }
 
+    /// How many parameters does the named user-defined function declare?
+    ///
+    /// `None` when the name is not bound to a user-defined function — a built-in,
+    /// a non-function value, or absent entirely. Callers that need to shape their
+    /// argument list to a function they did not write (the `main` entry point) ask
+    /// this first, rather than calling and interpreting the failure: a call that
+    /// fails has already run whatever the function did before it failed.
+    pub fn function_arity(&self, name: &str) -> Option<usize> {
+        let value = self
+            .environment
+            .borrow()
+            .get(name)
+            .or_else(|| self.globals.borrow().get(name));
+        match value {
+            Some(Value::Function(f)) => Some(f.params.len()),
+            _ => None,
+        }
+    }
+
     /// Call a function by name from the environment
     pub fn call_function_by_name(
         &mut self,
@@ -26457,6 +26476,42 @@ mod tests {
             .map_err(|e| RuntimeError::new(e.to_string()))?;
         let mut interp = Interpreter::new();
         interp.execute(&file)
+    }
+
+    /// Load a file's definitions and hand back the interpreter, so a test can
+    /// inspect what got registered rather than only what `main` returned.
+    fn interp_after(source: &str) -> Interpreter {
+        let mut parser = Parser::new(source);
+        let file = parser.parse_file().expect("parse");
+        let mut interp = Interpreter::new();
+        interp.execute(&file).expect("execute");
+        interp
+    }
+
+    #[test]
+    fn function_arity_reports_declared_parameter_count() {
+        // `sigil run-dir` used to pass an argv array to `main` unconditionally,
+        // so every zero-arg `main` died with "Expected 0 arguments, got 1". The
+        // fix shapes the call to the declared arity, which is only as good as
+        // this lookup.
+        let interp = interp_after("rite main() { ⤺ 1; }");
+        assert_eq!(interp.function_arity("main"), Some(0));
+
+        let interp = interp_after("rite main(args) { ⤺ 1; }");
+        assert_eq!(interp.function_arity("main"), Some(1));
+    }
+
+    #[test]
+    fn function_arity_is_none_for_anything_that_is_not_a_user_function() {
+        // The caller falls back to passing argv when this is None, so it must not
+        // report Some for a non-function — an absent `main` has to reach
+        // `call_function_by_name` and produce its own error, not be treated as
+        // zero-arg here.
+        let interp = interp_after("rite other() { ⤺ 1; }");
+        assert_eq!(interp.function_arity("main"), None);
+
+        let interp = interp_after("rite main() { ⤺ 1; }");
+        assert_eq!(interp.function_arity("no_such_function"), None);
     }
 
     #[test]

--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -54,7 +54,7 @@ fn main() -> ExitCode {
         eprintln!("Commands:");
         eprintln!("  run <file>      Execute a Sigil file (interpreted)");
         eprintln!("  run-dir <dir>   Execute all .sg/.sigil files in dir (multi-module)");
-        eprintln!("  run-ws [bin]    Run a workspace (reads Sigil.toml, optional bin crate name)");
+        eprintln!("  run-ws [bin]    Run a workspace (reads Sigil.toml, optional bin tome name)");
         eprintln!("  jit <file>      Execute a Sigil file (JIT compiled, fast)");
         eprintln!("  llvm <file>     Execute a Sigil file (LLVM backend, fastest)");
         eprintln!("  compile <file>  Compile to native executable (AOT, --lto for LTO)");
@@ -700,7 +700,7 @@ fn run_directory(dir_path: &str, program_args: &[String]) -> ExitCode {
         dir_name.to_string()
     };
 
-    eprintln!("Crate name: {}", crate_name);
+    eprintln!("Tome name: {}", crate_name);
 
     // Set up interpreter state for multi-module project
     interpreter.set_current_source_dir(Some(abs_dir.to_string_lossy().to_string()));
@@ -747,28 +747,39 @@ fn run_directory(dir_path: &str, program_args: &[String]) -> ExitCode {
         }
     }
 
-    // Create program args array
-    let args_value = sigil_parser::Value::Array(
-        std::rc::Rc::new(std::cell::RefCell::new(
-            program_args.iter()
-                .map(|s| sigil_parser::Value::String(std::rc::Rc::new(s.clone())))
-                .collect()
-        ))
-    );
+    call_main(&mut interpreter, program_args)
+}
 
-    // Try to call main with args
-    match interpreter.call_function_by_name("main", vec![args_value]) {
-        Ok(value) => {
-            // Check if result is an exit code
-            match &value {
-                sigil_parser::Value::Int(code) => ExitCode::from(*code as u8),
-                sigil_parser::Value::Null => ExitCode::SUCCESS,
-                _ => {
-                    println!("{}", value);
-                    ExitCode::SUCCESS
-                }
+/// Invoke the entry point and turn its result into a process exit code.
+///
+/// `main` may be written either way — `rite main()` or `rite main(args)` — so the
+/// argument list is shaped to the arity the program actually declares. Asking
+/// first matters: calling with the wrong count and retrying on failure runs
+/// `main` a second time, repeating every side effect it performed before it
+/// failed, and reports the retry's arity complaint in place of the real error.
+fn call_main(interpreter: &mut Interpreter, program_args: &[String]) -> ExitCode {
+    let args = match interpreter.function_arity("main") {
+        // Zero-arg `main` is the common shape and takes nothing.
+        Some(0) => vec![],
+        _ => vec![sigil_parser::Value::Array(std::rc::Rc::new(
+            std::cell::RefCell::new(
+                program_args
+                    .iter()
+                    .map(|s| sigil_parser::Value::String(std::rc::Rc::new(s.clone())))
+                    .collect(),
+            ),
+        ))],
+    };
+
+    match interpreter.call_function_by_name("main", args) {
+        Ok(value) => match &value {
+            sigil_parser::Value::Int(code) => ExitCode::from(*code as u8),
+            sigil_parser::Value::Null => ExitCode::SUCCESS,
+            _ => {
+                println!("{}", value);
+                ExitCode::SUCCESS
             }
-        }
+        },
         Err(e) => {
             eprintln!("Runtime error: {}", e);
             ExitCode::from(1)
@@ -858,7 +869,7 @@ fn run_workspace(bin_name: Option<&str>, program_args: &[String]) -> ExitCode {
         }
     }
 
-    eprintln!("Found {} crates:", members.len());
+    eprintln!("Found {} tomes:", members.len());
     for member in &members {
         eprintln!("  - {}", member);
     }
@@ -1122,16 +1133,16 @@ fn run_workspace(bin_name: Option<&str>, program_args: &[String]) -> ExitCode {
         interpreter.set_current_module(None);
     }
 
-    eprintln!("All crates loaded successfully.");
+    eprintln!("All tomes loaded successfully.");
 
     // Check we found a binary crate to run
     let binary_crate = match binary_crate {
         Some(name) => name,
         None => {
             if let Some(name) = bin_name {
-                eprintln!("Error: Binary crate '{}' not found in workspace", name);
+                eprintln!("Error: Binary tome '{}' not found in workspace", name);
             } else {
-                eprintln!("Error: No binary crate found in workspace (no main.sigil)");
+                eprintln!("Error: No binary tome found in workspace (no main.sigil)");
             }
             return ExitCode::from(1);
         }
@@ -1139,47 +1150,7 @@ fn run_workspace(bin_name: Option<&str>, program_args: &[String]) -> ExitCode {
 
     eprintln!("Running binary: {}\n", binary_crate);
 
-    // Create program args array
-    let args_value = sigil_parser::Value::Array(
-        std::rc::Rc::new(std::cell::RefCell::new(
-            program_args.iter()
-                .map(|s| sigil_parser::Value::String(std::rc::Rc::new(s.clone())))
-                .collect()
-        ))
-    );
-
-    // Try to call main
-    match interpreter.call_function_by_name("main", vec![args_value.clone()]) {
-        Ok(value) => {
-            match &value {
-                sigil_parser::Value::Int(code) => ExitCode::from(*code as u8),
-                sigil_parser::Value::Null => ExitCode::SUCCESS,
-                _ => {
-                    println!("{}", value);
-                    ExitCode::SUCCESS
-                }
-            }
-        }
-        Err(e) => {
-            // Try calling main with no args
-            match interpreter.call_function_by_name("main", vec![]) {
-                Ok(value) => {
-                    match &value {
-                        sigil_parser::Value::Int(code) => ExitCode::from(*code as u8),
-                        sigil_parser::Value::Null => ExitCode::SUCCESS,
-                        _ => {
-                            println!("{}", value);
-                            ExitCode::SUCCESS
-                        }
-                    }
-                }
-                Err(e2) => {
-                    eprintln!("Runtime error: {}", e2);
-                    ExitCode::from(1)
-                }
-            }
-        }
-    }
+    call_main(&mut interpreter, program_args)
 }
 
 #[cfg(feature = "jit")]
@@ -1833,7 +1804,7 @@ fn rust_compile_workspace(
     };
 
     if crate_dirs.is_empty() {
-        eprintln!("No Sigil crates found in workspace");
+        eprintln!("No Sigil tomes found in workspace");
         return ExitCode::from(1);
     }
 
@@ -1843,7 +1814,7 @@ fn rust_compile_workspace(
         return ExitCode::from(1);
     }
 
-    println!("Compiling {} crates to Rust...", crate_dirs.len());
+    println!("Compiling {} tomes to Rust...", crate_dirs.len());
 
     // Configure codegen options
     let options = RustCodegenOptions {
@@ -1968,7 +1939,7 @@ fn rust_compile_workspace(
         }
     }
 
-    println!("\nCompiled {}/{} crates successfully", success_count, crate_dirs.len());
+    println!("\nCompiled {}/{} tomes successfully", success_count, crate_dirs.len());
 
     if success_count > 0 {
         ExitCode::SUCCESS


### PR DESCRIPTION
Closes #72, closes #73.

## #72 — every zero-arg `main` errors

`run-dir` built an argv array and passed it to `main` unconditionally, so the common shape failed outright:

```
$ sigil run-dir .
Loading 1 modules from '.':
  - main.sigil
Runtime error: [R0000] Expected 0 arguments, got 1 (func=Some("main"), params=[])
```

**`run-ws` had the same call, with a fallback that is worse than the bug it hides.** On any error it called `main` a second time with no arguments. So a one-arg `main` that fails partway through is run **again**, repeating every side effect it already performed — and the retry's arity complaint is printed in place of the real error.

Both now ask the interpreter what `main` declares, via a new `Interpreter::function_arity`. Asking rather than calling-and-retrying is the whole point: a call that failed has already run whatever the function did before it failed, so failure is not a thing you can retry your way out of. The duplicated exit-code handling folds into one `call_main`.

## #73 — the Rustism

The issue asked for a sweep, not one string, so all nine user-facing occurrences in `main.rs` move to "tome". `[LLVM]`/`[DEBUG]`/`[IMPL-REG]` diagnostics keep "crate" — they name internal structures, not user vocabulary.

## Verification

| | result |
|---|---|
| zero-arg `main` via `run-dir` | exits **42**, its return value (was: error, exit 1) |
| one-arg `main`, `run-dir . -- alpha beta` | `args·len()` = **2**, unchanged from develop |
| label | `Tome name: dirtest` |
| lib suite | **561 passed**, 2 failed, 0 ignored |

The 2 failures are `llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}` — pre-existing on develop, untouched. Baseline was 559/2 after #87; the +2 are the new arity tests.

Reproducing note: `stdlib::tests::test_parser_nested_brackets` overflows the default thread stack on develop too. Use `RUST_MIN_STACK=33554432` or you will misread a pre-existing limit as a regression.

No CLI integration harness exists (`parser/tests/` holds `.sigil` fixtures, not Rust tests), so the regression tests cover `function_arity` directly — including that it returns `None` for an absent `main`, so the caller falls through to `call_function_by_name`'s own error rather than silently treating it as zero-arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X791QDdm9Y6F3fAoLFrQ5e