### PR TITLE
fix(llvm): make codegen respect the verdict sigil check already reached

### DIFF
--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -1193,6 +1193,40 @@ fn jit_file(path: &str) -> ExitCode {
     }
 }
 
+/// Type-check a source file before handing it to LLVM codegen.
+///
+/// `sigil check` already refuses these programs, but `sigil llvm` and
+/// `sigil compile` used to walk straight past that verdict into codegen, where
+/// an ill-typed program becomes malformed IR: at best the LLVM module verifier
+/// rejects it after the whole module has been dumped to stdout, at worst the
+/// JIT runs it and segfaults. Gating here makes the codegen paths agree with
+/// `sigil check`, and turns those failures back into source-level diagnostics.
+///
+/// Returns `Err(ExitCode)` if the caller should stop.
+#[cfg(feature = "llvm")]
+fn typecheck_before_codegen(path: &str, source: &str) -> Result<(), ExitCode> {
+    let mut parser = Parser::new(source);
+    match parser.parse_file() {
+        Ok(ast) => {
+            let mut type_checker = TypeChecker::new();
+            if let Err(type_errors) = type_checker.check_file(&ast) {
+                for err in &type_errors {
+                    eprintln!("Type error in '{}': {}", path, err.message);
+                    for note in &err.notes {
+                        eprintln!("  note: {}", note);
+                    }
+                }
+                return Err(ExitCode::from(1));
+            }
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("Parse error in '{}': {}", path, e);
+            Err(ExitCode::from(1))
+        }
+    }
+}
+
 #[cfg(feature = "llvm")]
 fn llvm_file(path: &str) -> ExitCode {
     use inkwell::context::Context;
@@ -1204,6 +1238,10 @@ fn llvm_file(path: &str) -> ExitCode {
             return ExitCode::from(1);
         }
     };
+
+    if let Err(code) = typecheck_before_codegen(path, &source) {
+        return code;
+    }
 
     // Create LLVM context and compiler
     let context = Context::create();
@@ -1262,6 +1300,10 @@ fn compile_file(path: &str, output: &str, use_lto: bool, use_tls: bool, use_cuda
             return ExitCode::from(1);
         }
     };
+
+    if let Err(code) = typecheck_before_codegen(path, &source) {
+        return code;
+    }
 
     // Create LLVM context and compiler in AOT mode
     let context = Context::create();


### PR DESCRIPTION
## The problem

`sigil check` refuses an ill-typed program. `sigil llvm` and `sigil compile` never asked it. They read the source, parsed it, skipped the type checker entirely, and went straight into codegen — so an ill-typed program became malformed IR, and the user found out in one of three ways, none of them a diagnostic.

**The module verifier catches it, after dumping the whole module.** On develop today, `sigil llvm` on a call with the wrong argument count prints the entire LLVM module to stdout and then:

```
Runtime error in 'P1_023_too_few_args_function.sg': Module verification failed: Incorrect number of arguments passed to called function!
  %call = tail call i64 @add(i64 1)
```

The user wrote `add(1)` against `rite add(a: i64, b: i64)`. They are handed generated IR.

**Or the JIT runs it and dies.** `examples/data_pipeline.sigil` exits **139** — SIGSEGV — on develop.

**Or it compiles to something that merely misbehaves**, which is the case nobody notices.

## The change

Run the type checker as a gate ahead of codegen in both paths, reporting against the source file. The same input now gives:

```
Type error in 'P1_023_too_few_args_function.sg': expected 2 arguments, found 1
```

exit 1, nothing on stdout.

This **introduces no new opinion about what is well-typed.** The gate calls the same `TypeChecker::check_file` that `sigil check` already calls. It only makes the codegen paths stop ignoring a verdict that the toolchain had already reached.

## What it rejects that develop accepts

I swept two corpora with a gated build and compared against a develop build.

**jormungandr positive spec tests — 636 files with `.expected`: 1 rejected, zero false positives.** The single rejection is a true positive: `12_quantum/P0_005_no_cloning.sg` is a negative test whose own header says `// EXPECT: Compile error - cannot invoke linear value twice`, misfiled with a `.expected` rather than an `.error_expected` extension. It is left alone here.

**`examples/` — 102 files: 5 rejected.** `sigil check` on develop **already reports the same error for all five**, so none is newly condemned:

| file | error, identical from `sigil check` on develop | develop `sigil llvm` |
|---|---|---|
| `claude_evidence_test.sigil` | evidence mismatch in argument 1: expected known (!), found reported (~) | exit 0 |
| `claude_meditation.sigil` | evidence mismatch in return type of 'consider': expected uncertain (?), found reported (~) | exit 0 |
| `evidence_inference.sigil` | evidence mismatch in return type of 'validate_user': expected known (!), found reported (~) | exit 0 |
| `sigil_test.sg` | type mismatch in argument 1: expected string, found &str | exit 0 |
| `data_pipeline.sigil` | concat operand must be string | **exit 139 (SIGSEGV)** |

So four examples that compile and run on develop today will now be rejected, and one that currently segfaults becomes a clean diagnostic.

**Those four are the reviewable question in this PR.** Either the examples are wrong, or the evidence rules and the `string`/`&str` relation are too strict in the checker — and if it is the latter, that is a checker bug that `sigil check` users are already hitting. I have deliberately not touched the examples or the checker, so this change stays one thing. Happy to follow up whichever way you call it.

The three examples CI checks (`simple`, `hello`, `pipes`) all still compile.

## Note on cost

The gate parses the source a second time; both callers parse again for codegen. Measurable only on large inputs. Left as is rather than restructuring the two call sites in a change about diagnostics.

## Tests

`RUST_MIN_STACK=33554432 cargo test --lib` from `parser/`:

- develop: **561 passed, 2 failed**
- this branch: **561 passed, 2 failed**

Unchanged. Both failures are the pre-existing `llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}`.

## Provenance

Rescued from uncommitted working-tree changes abandoned on `feature/s1-sigil-web-wasm-compat` since February/March 2026, preserved unmodified as `wip/s1-wasm-compat-rescue` (`ea9e541`). Not my original work. Found as the same 23-line block pasted into both functions; factored into one helper here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X791QDdm9Y6F3fAoLFrQ5e