### PR TITLE
test(spec): cover arity mismatch on static methods, constructors and functions

### DIFF
--- a/jormungandr/tests/spec/19_negative/P1_020_wrong_arity_static_method.error_expected
+++ b/jormungandr/tests/spec/19_negative/P1_020_wrong_arity_static_method.error_expected
@@ -1,0 +1,1 @@
+expected 1 arguments, found 3

--- a/jormungandr/tests/spec/19_negative/P1_020_wrong_arity_static_method.sg
+++ b/jormungandr/tests/spec/19_negative/P1_020_wrong_arity_static_method.sg
@@ -1,0 +1,18 @@
+// Negative Test: Wrong number of arguments on static method call
+// Should fail with argument count error
+// Priority: P1
+
+sigil Foo {
+    x: i64,
+}
+
+⊢ Foo {
+    rite bar(x: i64) → i64 {
+        x
+    }
+}
+
+rite main() {
+    ≔ r = Foo·bar(1, 2, 3);
+    println(r);
+}

--- a/jormungandr/tests/spec/19_negative/P1_022_wrong_arity_constructor.error_expected
+++ b/jormungandr/tests/spec/19_negative/P1_022_wrong_arity_constructor.error_expected
@@ -1,0 +1,1 @@
+expected 0 arguments, found 3

--- a/jormungandr/tests/spec/19_negative/P1_022_wrong_arity_constructor.sg
+++ b/jormungandr/tests/spec/19_negative/P1_022_wrong_arity_constructor.sg
@@ -1,0 +1,19 @@
+// Negative Test: Constructor called with wrong number of arguments
+// Should fail with argument count error
+// Priority: P1
+
+sigil Pair {
+    a: i64,
+    b: i64,
+}
+
+⊢ Pair {
+    rite new() → Pair {
+        Pair { a: 0, b: 0 }
+    }
+}
+
+rite main() {
+    ≔ p = Pair·new(1, 2, 3);
+    println(p.a);
+}

--- a/jormungandr/tests/spec/19_negative/P1_023_too_few_args_function.error_expected
+++ b/jormungandr/tests/spec/19_negative/P1_023_too_few_args_function.error_expected
@@ -1,0 +1,1 @@
+expected 2 arguments, found 1

--- a/jormungandr/tests/spec/19_negative/P1_023_too_few_args_function.sg
+++ b/jormungandr/tests/spec/19_negative/P1_023_too_few_args_function.sg
@@ -1,0 +1,12 @@
+// Negative Test: Too few arguments to free function
+// Should fail with argument count error
+// Priority: P1
+
+rite add(a: i64, b: i64) → i64 {
+    ⤺ a + b;
+}
+
+rite main() {
+    ≔ r = add(1);
+    println(r);
+}


### PR DESCRIPTION
## What

`19_negative` had exactly one arity test — `P0_008`, a free function called with the wrong number of arguments. The other call shapes were unpinned, so a regression in any of them would have passed unnoticed. This adds three:

| test | call | declaration |
|---|---|---|
| `P1_020_wrong_arity_static_method` | `Foo·bar(1, 2, 3)` | `rite bar(x: i64)` |
| `P1_022_wrong_arity_constructor` | `Pair·new(1, 2, 3)` | zero-argument `new` |
| `P1_023_too_few_args_function` | `add(1)` | `rite add(a: i64, b: i64)` |

All three pass on develop as-is. They lock in behaviour that already works; nothing here is a fix.

## The fourth test I did not include

The instance-method case is the interesting one, and it is left out on purpose. `f.get(99)` against `rite get(&this) → i64` never reaches the type checker — it is caught at runtime, and reports:

```
[R0000] Runtime error: Expected 1 arguments, got 2 (func=Some("get"), params=["self"])
```

That message counts the receiver as an argument, so a user who passed one argument too many is told they passed two, and it prints `func=Some("get"), params=["self"]` — interpreter internals in a user-facing diagnostic. The three tests above all get a clean `expected N arguments, found M` from the type checker; this path gets that instead.

Adding a test pinned to that string would enshrine it. Filed separately rather than committed here.

## Tests

`jormungandr/tests/run_tests_rust.sh`, full suite, with these three added:

**797 passed, 4 failed, 2 skipped.**

The four failures are `15_protocols` Kafka and AMQP tests failing with `Connection refused (os error 111)` against brokers not running locally. They fail identically without this change. The 2 skips are the `// SKIP`-marked network tests.

Note this suite is not run by CI — `.github/workflows/ci.yml` builds and runs `cargo test` only. These tests are for whoever runs the spec suite by hand.

## Provenance

Rescued from uncommitted working-tree changes abandoned on `feature/s1-sigil-web-wasm-compat` since February 2026, preserved as `wip/s1-wasm-compat-rescue` (`ea9e541`). Not my original work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X791QDdm9Y6F3fAoLFrQ5e