### PR TITLE
chore: ignore the static library the parser link step leaves at the crate root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,10 @@ jormungandr/build/.jormungandr_full.c
 # Python bytecode from tools/
 __pycache__/
 *.pyc
+
+# Native runtime static libraries linked at the parser crate root.
+# parser/runtime/.gitignore already ignores *.a beside the sources; the link
+# step also drops one here, and that copy was reaching `git status` untracked.
+# Deliberately narrow: sigil-web/src/*.wasm and jormungandr/src/*.sg.bak are
+# tracked on purpose, so no blanket *.wasm or *.bak rule belongs here.
+/parser/*.a


### PR DESCRIPTION
## What

`parser/runtime/.gitignore` already treats `*.a` as build output, but it only covers the runtime directory. Linking the native CUDA runtime also drops `libsigil_runtime_cuda.a` at `parser/` — one level up, outside that rule — where it sat untracked in `git status`, inviting someone to commit an 89KB static library.

One line: `/parser/*.a`.

## Why it is scoped this narrowly

The obvious instinct is a blanket `*.wasm` / `*.bak` rule. That would be wrong here. **50 files matching `.wasm`, `.a` or `.bak` are already tracked on develop**, apparently on purpose:

- seven `.wasm` in `sigil-web/src/` (`component`, `events`, `hooks`, `lib`, `runtime`, `signals`, `vdom`)
- more under `sigil-web/examples/`, `sigil-web/wasm-backup/`, `jormungandr/build/`, `parser/tests/`
- four `.sg.bak` under `jormungandr/src/`

A blanket rule would not untrack any of them — `.gitignore` does not touch tracked files — but it would misdescribe the repository and hide the next one that shows up. Whether checked-in `.wasm` build output is the right call is a real question; it is not this one, so this rule covers only the case that is unambiguous: a static library at a Rust crate root, already declared build output by the sibling `.gitignore` one directory down.

## Provenance

Found while inventorying artefacts alongside abandoned uncommitted work on `feature/s1-sigil-web-wasm-compat` (preserved as `wip/s1-wasm-compat-rescue`, `ea9e541`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X791QDdm9Y6F3fAoLFrQ5e