### PR TITLE
fix(interpreter): resolve module-qualified calls to lowercase functions (#95)

### DIFF
--- a/docs/findings/middledot-module-path-vs-method-call.md
+++ b/docs/findings/middledot-module-path-vs-method-call.md
@@ -1,0 +1,68 @@
+# `·` — module path or method call? Where the decision lives
+
+**Recorded:** 2026-09-10, closing #95.
+**History:** #61 → #86 → #87 → #95. The same ambiguity has been rediscovered
+four times; this note exists so it is not rediscovered a fifth.
+
+## The ambiguity
+
+In expression position `·` is overloaded:
+
+```sigil
+tome·lerp(a, b, t)     // path:        module → free function
+tag·to_string()        // method call: receiver → method
+```
+
+Both are `lowercase · lowercase (`. **No amount of lookahead separates them**,
+because the difference is not in the token stream at all — it is what the first
+segment is *bound* to. That is a name-resolution question, not a syntactic one.
+
+Every attempt to answer it with a wider parser guard has broken the other half:
+
+* **#61** made `·` a path separator more eagerly, so `tag·to_string()` became a
+  call to a path `tag·to_string` dispatched to a built-in of the wrong arity.
+* **#86** was the fallout: narrowing it back broke `geom·P·new(…)`, which turned
+  into a field access on a variable that was never bound —
+  `undefined variable: geom`.
+
+## What the parser decides
+
+`parse_type_path` (parser/src/parser.rs) accepts `·` as a path separator in
+expression position only when it can be sure syntactically:
+
+1. **In a type context** — `·` is unambiguous, types have no method calls (S5).
+2. **A path-keyword root** — `tome` and `super` are lexer keywords and can never
+   be values, so `tome·lerp(…)` is a path with no ambiguity to resolve. This is
+   why the `tome·` spelling was never affected by #95.
+3. **An uppercase root** — `HashMap·new()`.
+4. **#87: the `·ident` chain ahead reaches an uppercase segment** — Sigil types
+   are uppercase and methods are not, so `geom·P·new` reaches `P` and is a path,
+   while `tag·to_string` reaches nothing and stays a method call.
+
+Rule 4 is a *cover*, not a general solution: it only catches module paths that
+happen to name a type on the way.
+
+## What the interpreter decides (#95)
+
+`geom·lerp(…)` reaches nothing uppercase, so the parser leaves it as a method
+call on `geom`, and the parser is right to. The rest is settled in
+`Interpreter::module_qualified_path` (parser/src/interpreter.rs), on the one
+piece of information the parser does not have — the binding:
+
+* The receiver is **bound** → it is a value, and `value·method()` is a method
+  call. This is what keeps `tag·to_string()` working, and it is why a local
+  variable shadowing a scroll name still resolves to the variable.
+* The receiver is **unbound** *and* names a scroll in scope *and* that scroll
+  owns the member → retry it as the path it always was.
+
+The retry can only ever replace an error. An unbound receiver had exactly one
+possible outcome before — `undefined variable: geom` — so nothing that worked
+can be masked by it. The member check matters for the same reason: without it an
+unresolvable `geom·nosuchfn(…)` falls into the generic path-call machinery and
+comes back as an empty struct named `geom`, which is worse than the error.
+
+## If you are about to widen the parser guard
+
+Don't. `tome·lerp(…)` and `tag·to_string()` are lexically identical; whatever
+you add to tell them apart will get one of them wrong. Add the case to
+`module_qualified_path` instead, where the answer is knowable.

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -10832,6 +10832,103 @@ impl Interpreter {
         }
     }
 
+    /// The leftmost identifier of a `·`-separated chain, without allocating.
+    /// Every method call runs through this, so it must stay cheap.
+    fn receiver_root_name(receiver: &Expr) -> Option<&str> {
+        match receiver {
+            Expr::Path(path) => Some(path.segments.first()?.ident.name.as_str()),
+            Expr::Field { expr, .. } => Self::receiver_root_name(expr),
+            _ => None,
+        }
+    }
+
+    /// Rebuild a `·`-separated chain of bare identifiers into path segments.
+    ///
+    /// Only a bare chain can name a module, so anything else — a call, an index,
+    /// a literal, a segment carrying generics — ends the walk and yields `None`.
+    /// `outer·inner` reaches here as `Field { expr: Path(outer), field: inner }`,
+    /// which is why the `Field` arm exists.
+    fn receiver_path_segments(receiver: &Expr) -> Option<Vec<PathSegment>> {
+        match receiver {
+            Expr::Path(path) if path.segments.iter().all(|s| s.generics.is_none()) => {
+                Some(path.segments.clone())
+            }
+            Expr::Field { expr, field } => {
+                let mut segments = Self::receiver_path_segments(expr)?;
+                segments.push(PathSegment {
+                    ident: field.clone(),
+                    generics: None,
+                });
+                Some(segments)
+            }
+            _ => None,
+        }
+    }
+
+    /// Is this "method call" really a module-qualified path the parser could not
+    /// recognise? If so, hand back the path it should have been.
+    ///
+    /// #87 taught `parse_type_path` to accept `·` as a path separator after a
+    /// lowercase segment when the `·ident` chain ahead reaches an UPPERCASE one,
+    /// because Sigil types are uppercase and methods are not. That covers
+    /// `geom·P·new(…)`. It cannot cover `geom·lerp(…)`: nothing in that chain is
+    /// uppercase, so it is lexically identical to `tag·to_string()` and the
+    /// parser leaves it as a method call on `geom` (#95).
+    ///
+    /// No lookahead can separate the two, because the difference is what the
+    /// first segment is BOUND to — a name-resolution question, not a syntactic
+    /// one. So it is settled here, where the binding is known:
+    ///
+    /// * A bound name is a value, and `value·method()` is a method call. That is
+    ///   what keeps `tag·to_string()` working, and it is why a local variable
+    ///   shadowing a scroll name still resolves to the variable.
+    /// * An unbound name that names a scroll in scope was never a receiver. The
+    ///   only thing it could have produced is `undefined variable: geom`, so
+    ///   retrying it as a path replaces an error and can never mask a program
+    ///   that worked.
+    fn module_qualified_path(
+        &self,
+        receiver: &Expr,
+        method: &Ident,
+        type_args: &Option<Vec<TypeExpr>>,
+    ) -> Option<TypePath> {
+        if self.crate_modules.is_empty() {
+            return None;
+        }
+        // Reject a bound receiver before allocating anything: that is what almost
+        // every method call is, and this sits on the path of all of them.
+        if self
+            .environment
+            .borrow()
+            .get(Self::receiver_root_name(receiver)?)
+            .is_some()
+        {
+            return None;
+        }
+        let mut segments = Self::receiver_path_segments(receiver)?;
+        let module = segments
+            .iter()
+            .map(|s| s.ident.name.as_str())
+            .collect::<Vec<_>>()
+            .join("·");
+        if !self.crate_modules.contains(&module) {
+            return None;
+        }
+        // The module must actually own this member. Without the check, an
+        // unresolvable `geom·nosuchfn(…)` reaches the generic path-call machinery
+        // and comes back as an empty struct named `geom` -- silently wrong, and
+        // strictly worse than the `undefined variable: geom` it replaced.
+        let qualified = format!("{}·{}", module, method.name);
+        if self.globals.borrow().get(&qualified).is_none() && !self.types.contains_key(&qualified) {
+            return None;
+        }
+        segments.push(PathSegment {
+            ident: method.clone(),
+            generics: type_args.clone(),
+        });
+        Some(TypePath { segments })
+    }
+
     /// Method call with optional type arguments (generics/turbofish)
     fn eval_method_call_with_generics(
         &mut self,
@@ -10840,6 +10937,12 @@ impl Interpreter {
         args: &[Expr],
         type_args: &Option<Vec<TypeExpr>>,
     ) -> Result<Value, RuntimeError> {
+        // `geom·lerp(…)` is a module-qualified call the parser had to leave as a
+        // method call on an unbound `geom`; see `module_qualified_path`.
+        if let Some(path) = self.module_qualified_path(receiver, method, type_args) {
+            return self.eval_call(&Expr::Path(path), args);
+        }
+
         // Collect const generics from type_args to inject into the method's environment
         // These will be consumed by call_function when the method is actually invoked
         if let Some(ref generics) = type_args {
@@ -26653,6 +26756,118 @@ mod tests {
                 ⤺ p·scaled(2.0);
             }";
         assert!(matches!(run(source), Ok(Value::Float(v)) if v == 6.0));
+    }
+
+    /// The scroll every #95 test resolves against: a type reached through an
+    /// uppercase segment, a free function that is not, and an uppercase const.
+    const GEOM_SCROLL: &str = "\
+        scroll geom {
+            ☉ Σ P { ☉ x: f32 }
+            ⊢ P {
+                ☉ rite new(x: f32) -> Self { Self { x } }
+                ☉ rite scaled(self, k: f32) -> f32 { self.x * k }
+            }
+            ☉ rite lerp(a: f32, b: f32, t: f32) -> f32 { a + (b - a) * t }
+            ☉ const EPSILON: f32 = 0.5;
+        }
+        ";
+
+    #[test]
+    fn module_qualified_call_to_a_lowercase_function_resolves() {
+        // #95. #87 accepts `·` as a path separator after a lowercase segment only
+        // when the `·ident` chain ahead reaches an UPPERCASE one, because Sigil
+        // types are uppercase and methods are not. `geom·lerp(…)` reaches nothing
+        // uppercase, so the parser must leave it as a method call on `geom` --
+        // it is lexically indistinguishable from `tag·to_string()`.
+        //
+        // It is settled in the interpreter instead: `geom` is unbound and names a
+        // scroll, so the "method call" is retried as the path it always was.
+        let source = format!("{}rite main() {{ ⤺ geom·lerp(0.0, 10.0, 0.5); }}", GEOM_SCROLL);
+        assert!(matches!(run(&source), Ok(Value::Float(v)) if v == 5.0));
+    }
+
+    #[test]
+    fn module_qualified_type_method_still_resolves_alongside_the_lowercase_fallback() {
+        // The #87 shape, asserted against the same scroll that now also carries a
+        // free function: the fallback must not disturb a path the parser already
+        // builds for itself.
+        let source = format!("{}rite main() {{ ⤺ geom·P·new(3.0).x; }}", GEOM_SCROLL);
+        assert!(matches!(run(&source), Ok(Value::Float(v)) if v == 3.0));
+    }
+
+    #[test]
+    fn module_qualified_uppercase_const_still_resolves() {
+        // `geom·EPSILON` reaches an uppercase segment, so it is a path before the
+        // interpreter ever sees it. Pinned because it is the sibling spelling of
+        // `geom·lerp` at the call sites #95 blocks.
+        let source = format!("{}rite main() {{ ⤺ geom·EPSILON; }}", GEOM_SCROLL);
+        assert!(matches!(run(&source), Ok(Value::Float(v)) if v == 0.5));
+    }
+
+    #[test]
+    fn a_bound_receiver_is_still_a_method_call_even_when_the_scroll_has_that_name() {
+        // The fallback keys on the receiver being UNBOUND. `p` is bound, so
+        // `p·scaled(…)` stays a method call -- and would even if the scroll
+        // exported a free function of the same name.
+        let source = format!(
+            "{}rite main() {{ ≔ p = geom·P·new(3.0); ⤺ p·scaled(2.0); }}",
+            GEOM_SCROLL
+        );
+        assert!(matches!(run(&source), Ok(Value::Float(v)) if v == 6.0));
+    }
+
+    #[test]
+    fn a_variable_shadowing_a_scroll_name_resolves_to_the_variable() {
+        // A local named `geom` shadows the scroll `geom`. Because the fallback
+        // only fires on an unbound name, `geom·scaled(2.0)` dispatches to the
+        // variable's method and never to the scroll -- 3.0 * 2.0, not the
+        // scroll's `lerp`.
+        let source = format!(
+            "{}rite main() {{ ≔ geom = geom·P·new(3.0); ⤺ geom·scaled(2.0); }}",
+            GEOM_SCROLL
+        );
+        assert!(matches!(run(&source), Ok(Value::Float(v)) if v == 6.0));
+    }
+
+    #[test]
+    fn an_undefined_receiver_still_reports_the_undefined_name() {
+        // A name that is neither bound nor a scroll must keep reporting itself,
+        // not be swallowed by the retry.
+        let source = format!("{}rite main() {{ ⤺ nosuch·whatever(1.0); }}", GEOM_SCROLL);
+        let err = run(&source).expect_err("nosuch is undefined");
+        assert_eq!(err.code, RuntimeErrorCode::UndefinedVariable);
+        assert!(
+            err.to_string().contains("nosuch"),
+            "error should name the undefined receiver, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn a_scroll_member_that_does_not_exist_is_an_error_not_an_empty_struct() {
+        // The retry is refused when the scroll has no such member. Without that
+        // guard the rewritten path reaches the generic path-call machinery and
+        // comes back as an empty struct named `geom` -- silently wrong, and worse
+        // than the error it replaced.
+        let source = format!("{}rite main() {{ ⤺ geom·nosuchfn(1.0); }}", GEOM_SCROLL);
+        let err = run(&source).expect_err("geom·nosuchfn does not exist");
+        assert_eq!(err.code, RuntimeErrorCode::UndefinedVariable);
+    }
+
+    #[test]
+    fn a_nested_scroll_qualified_call_to_a_lowercase_function_resolves() {
+        // `outer·inner·twice(…)` reaches the interpreter as a method call whose
+        // receiver is `Field { Path(outer), inner }`, not a one-segment path, so
+        // the receiver has to be flattened back into path segments before the
+        // scroll lookup can see `outer·inner`.
+        let source = "\
+            scroll outer {
+                scroll inner {
+                    ☉ rite twice(a: f32) -> f32 { a * 2.0 }
+                }
+            }
+            rite main() { ⤺ outer·inner·twice(2.0); }";
+        assert!(matches!(run(source), Ok(Value::Float(v)) if v == 4.0));
     }
 
     #[test]


### PR DESCRIPTION
## What

`geom·lerp(0.0, 10.0, 0.5)` failed with `[R0003] undefined variable: geom`, while `geom·P·new(3.0).x` and `geom·EPSILON` both resolved. Module-qualified paths that end in a **lowercase** free function were unreachable.

```
scroll geom {
    ☉ Σ P { ☉ x: f32 }
    ⊢ P { ☉ rite new(x: f32) -> Self { Self { x } } }
    ☉ rite lerp(a: f32, b: f32, t: f32) -> f32 { a + (b - a) * t }
    ☉ const EPSILON: f32 = 0.001;
}
```

| expression | before | after |
|---|---|---|
| `geom·P·new(3.0).x` | `3` | `3` |
| `geom·EPSILON` | `0.001` | `0.001` |
| `geom·lerp(0.0, 10.0, 0.5)` | ❌ `undefined variable: geom` | `5` |
| `outer·inner·twice(2.0)` | ❌ `undefined variable: outer` | `4` |

## Why not the parser

#87 accepts `·` as a path separator after a lowercase segment only when the `·ident` chain ahead reaches an **uppercase** one — Sigil types are uppercase and methods are not, so `geom·P·new` reaches `P` and is a path while `tag·to_string` reaches nothing and is a method call. `geom·lerp` reaches nothing uppercase either, so it is *lexically identical* to `tag·to_string()`.

No lookahead separates those two, because the difference is what the first segment is **bound** to — name resolution, not syntax. Widening the guard is what #61 did, and #86 was the fallout. The parser is left exactly as it is.

## Where the fix is

`Interpreter::module_qualified_path` in `parser/src/interpreter.rs`, consulted at the top of `eval_method_call_with_generics`. A method call is retried as a path when all three hold:

1. the receiver is a bare `·` chain of identifiers whose root is **unbound**,
2. that chain names a scroll in scope, and
3. the scroll actually owns the named member.

**(1) is what makes this safe.** An unbound receiver had exactly one possible outcome before — `undefined variable: geom` — so the retry can only replace an error and can never mask a program that worked. A *bound* receiver never reaches the fallback, which is what keeps `tag·to_string()` a method call and lets a local variable shadow a scroll of the same name.

**(3) matters more than it looks.** Without it, an unresolvable `geom·nosuchfn(…)` reaches the generic path-call machinery and comes back as an empty struct named `geom` — silently wrong, and strictly worse than the error it replaced.

Nested scrolls work too: `outer·inner·twice(…)` arrives as a method call on `Field { Path(outer), inner }`, so the receiver is flattened back into path segments before the scroll lookup. The bound-receiver rejection runs first and allocates nothing, since it sits on the path of every method call in the interpreter.

`docs/findings/middledot-module-path-vs-method-call.md` records the decision, which #95 asked for — this ambiguity has now been rediscovered four times (#61, #86, #87, #95).

## Tests

Eight new tests in `interpreter::tests`, pinning both halves of the decision:

- `module_qualified_call_to_a_lowercase_function_resolves` — the bug
- `module_qualified_type_method_still_resolves_alongside_the_lowercase_fallback` — #87 undisturbed
- `module_qualified_uppercase_const_still_resolves`
- `a_bound_receiver_is_still_a_method_call_even_when_the_scroll_has_that_name`
- `a_variable_shadowing_a_scroll_name_resolves_to_the_variable`
- `an_undefined_receiver_still_reports_the_undefined_name`
- `a_scroll_member_that_does_not_exist_is_an_error_not_an_empty_struct`
- `a_nested_scroll_qualified_call_to_a_lowercase_function_resolves`

Measured with `RUST_MIN_STACK=33554432 cargo test --no-fail-fast` from `parser/`:

| | lib | bin |
|---|---|---|
| `origin/develop` @ `1e05b7f` | 561 passed, 2 failed | 41 passed, 0 failed |
| this branch | 569 passed, 2 failed | 41 passed, 0 failed |

+8 = the eight new tests. The 2 failures are the pre-existing `llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}`, identical on both. `cargo check --no-default-features --features jit,llvm,wasm,lsp,protocols` (what CI builds) is clean.

## One correction to the issue

#95 says aether's `tome·lerp` sites do not resolve. **They do, and they did before this PR.** `tome` and `super` are lexer keywords and can never be values, so `parse_type_path` already treats them as unconditional path roots — `tome·lerp(…)` parses as `Call { func: Path[tome, lerp] }`, never as a method call, and the #95 mechanism never touched it.

Verified by running `engine/math/src/{lib,vector}.sg` from aether's `claude/sigil-deglam-math` (read-only export) against both binaries: `Vec2·lerp` returns the correct interpolation on `develop` and on this branch alike, and instrumenting the new fallback shows it never fires during that run.

What that de-glam track is actually blocked by, in the same files, is two unrelated bugs:

- **`run-dir` is nondeterministic.** The same directory and the same binary alternate between the right answer and `[R0000] Invalid struct operation`, roughly 40% failures, on `develop` and on this branch equally. Looks like module load order.
- **No operator impls on the `Vec` types.** `normalize()` / `normalize_or_zero()` do `self / len`, which bottoms out in `Type mismatch in binary operation: Struct(Self, …) Div …` — `vector.sg` relies on `invoke std·ops·{Div, …}` and `//@ rune: derive(…)` rather than a Sigil `⊢ Div ∀ Vec2` impl.

Both are worth their own issues; neither is #95.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X791QDdm9Y6F3fAoLFrQ5e
