### PR TITLE
fix(interpreter): make run-dir deterministic — bind Self through a scroll, stop a HashMap picking the type

### DIFF
--- a/docs/findings/run-dir-nondeterminism-self-named-values.md
+++ b/docs/findings/run-dir-nondeterminism-self-named-values.md
@@ -1,0 +1,117 @@
+# Why `run-dir` alternated between the right answer and "Invalid struct operation"
+
+**Recorded:** 2026-09-10, closing #104.
+
+Same directory, same binary, ~40% of runs failing with
+`[R0000] Invalid struct operation`. Reported against `aether`'s
+`engine/math/src/{lib,vector}.sg`. It nearly produced a false A/B result: a fix
+looked like a regression when the two runs simply landed differently.
+
+Two defects compose. Neither is sufficient alone, which is why a minimal
+two-file case did not reproduce it and the real one did.
+
+## 1. The trigger: `Self` is not bound through a module-qualified call
+
+`eval_call` decides what `Self` means for the callee from the call path
+(`interpreter.rs`, `type_name_for_self`). It tested only the **first** segment:
+
+```rust
+let first = &path.segments[0].ident.name;
+if self.types.contains_key(first) { Some(first.clone()) } else { None }
+```
+
+That is right for `P·new(…)` and wrong for `geom·P·new(…)`, where segment 0 is
+the scroll. `Self` stayed unbound, and a `Self { .. }` literal in the callee
+falls back to its own raw name — so the constructor returned a struct named,
+literally, **`"Self"`**.
+
+Nothing is filed under `"Self"`. `lookup_operator_impl` keys operator impls by
+the value's struct name, so the next `+` on that value found no `impl Add` and
+reported `Invalid struct operation`.
+
+This half is deterministic: with two modules it fails every time.
+
+## 2. The nondeterminism: recovering a `Self`-named value walked a `HashMap`
+
+A `Self`-named value is not a dead end — a method call on one is recovered by
+matching its field names against every registered struct and using the first
+type that fits. That scan (two copies, both in `eval_method_call`) iterated
+`self.types`, a `HashMap`, and returned on the first hit:
+
+```rust
+for (type_name, type_def) in &self.types {
+    …
+    let matches = field_names.iter().all(|f| def_fields.contains(f));
+    if matches { /* call type_name·method, bind Self to type_name */ }
+}
+```
+
+`HashMap` iteration order is seeded per process. The match is also a **subset**
+test, so `{x}` matches every struct that has an `x`. With more than one
+candidate the recovered type — and therefore the name of whatever the method
+returns — changed from run to run.
+
+That is the coin flip. In the reduced case below the scan lands on `P`,
+`shapes·P`, `Q` or `shapes·Q`; only bare `P` carries the `Add` impl, so the
+program worked in 8 runs out of 20 and reported `Invalid struct operation` in
+the other 12.
+
+```sigil
+// shapes.sg — two structs of the same shape, one with an operator impl
+☉ Σ P { ☉ x: f32 }
+⊢ P {
+    ☉ rite new(x: f32) -> Self { Self { x } }
+    ☉ rite twice(self) -> Self { Self·new(self.x * 2.0) }
+}
+⊢ Add ∀ P {
+    type Output = Self;
+    rite add(self, o: Self) -> Self { Self·new(self.x + o.x) }
+}
+☉ Σ Q { ☉ x: f32 }
+⊢ Q {
+    ☉ rite new(x: f32) -> Self { Self { x } }
+    ☉ rite twice(self) -> Self { Self·new(self.x * 2.0) }
+}
+
+// main.sg
+☉ rite main() -> !i32 {
+    ≔ a = shapes·P·new(1.0);   // (1) returns a struct named "Self"
+    ≔ b = a·twice();           // (2) recovered as P, shapes·P, Q or shapes·Q
+    ≔ c = b + b;               // succeeds only when (2) landed on P
+    println(c·x);
+    ⤺ 0;
+}
+```
+
+## What was ruled out
+
+Recorded so it is not re-checked. Neither of these is the cause:
+
+* **File iteration order.** `run_directory` (`main.rs`) sorts lib-first,
+  main-last, and the comparator is consistent for those cases.
+* **Impl-registry order.** `ImplRegistry`'s `generic_impls` and
+  `concrete_impls` are `Vec`s, and `operator_impls`' candidate lists are `Vec`s
+  too. All stable.
+
+## The fix
+
+* `type_name_for_self` takes the type from the path *prefix* — everything
+  before the final segment — preferring its bare last segment, which is the
+  name an unqualified call binds and the name impl methods and operator impls
+  are filed under, and falling back to the fully qualified prefix.
+* Both recovery scans go through `struct_types_matching_fields`, which returns
+  candidates in a stable order: exact field-set matches first, then supersets,
+  each group sorted by name.
+* The enum-variant suffix scan in `eval_path` had the same shape — first hit
+  while walking `self.types` — and is now collected and sorted the same way.
+
+Fixing only the trigger would leave the coin flip in place for any other way a
+value acquires the name `Self`; fixing only the scan would make the failure
+deterministic rather than absent. Both are needed.
+
+## The general rule
+
+**A `HashMap` may not decide name resolution.** Anywhere the interpreter walks
+`self.types` (or any other hash container) and returns on the first match, the
+answer is per-process random and the symptom is an intermittent failure with no
+input that explains it. Collect, order, then choose.

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -5724,25 +5724,34 @@ impl Interpreter {
                     }
                 }
 
-                // Fallback: search all enums for matching type name suffix and variant
-                for (actual_type_name, type_def) in &self.types {
-                    if let TypeDef::Enum(enum_def) = type_def {
-                        // Check if this enum name ends with our type name
-                        // (handles module·DType matching DType)
-                        let matches = actual_type_name == &type_name_direct
-                            || actual_type_name == &type_name_qualified
-                            || actual_type_name.ends_with(&format!("·{}", type_name_direct));
-
-                        if matches {
-                            for variant in &enum_def.variants {
-                                if &variant.name.name == variant_name {
-                                    if matches!(variant.fields, crate::ast::StructFields::Unit) {
-                                        return Ok(Value::Variant {
-                                            enum_name: actual_type_name.clone(),
-                                            variant_name: variant_name.clone(),
-                                            fields: None,
-                                        });
-                                    }
+                // Fallback: search all enums for matching type name suffix and
+                // variant. Collected and sorted before the search rather than
+                // returning the first hit while walking `self.types`: that is a
+                // HashMap, so the winner among several matching enums varied
+                // from one process to the next.
+                let suffix = format!("·{}", type_name_direct);
+                let mut enum_names: Vec<String> = self
+                    .types
+                    .iter()
+                    .filter(|(name, type_def)| {
+                        matches!(type_def, TypeDef::Enum(_))
+                            && (*name == &type_name_direct
+                                || *name == &type_name_qualified
+                                || name.ends_with(&suffix))
+                    })
+                    .map(|(name, _)| name.clone())
+                    .collect();
+                enum_names.sort();
+                for actual_type_name in &enum_names {
+                    if let Some(TypeDef::Enum(enum_def)) = self.types.get(actual_type_name) {
+                        for variant in &enum_def.variants {
+                            if &variant.name.name == variant_name {
+                                if matches!(variant.fields, crate::ast::StructFields::Unit) {
+                                    return Ok(Value::Variant {
+                                        enum_name: actual_type_name.clone(),
+                                        variant_name: variant_name.clone(),
+                                        fields: None,
+                                    });
                                 }
                             }
                         }
@@ -5963,6 +5972,44 @@ impl Interpreter {
             Value::Array(_) => ty.starts_with('[') || ty.starts_with("Vec"),
             _ => false,
         }
+    }
+
+    /// The struct types a `Self`-named value could have been built from, in a
+    /// stable order.
+    ///
+    /// A value carries the name `Self` when a `Self { .. }` literal is
+    /// evaluated with no `Self` binding in scope, so recovering its type from
+    /// its field names is a guess. It has to be the *same* guess on every run:
+    /// `self.types` is a `HashMap`, and walking it to take the first match
+    /// chose a different type per process, which made any program reaching
+    /// here alternate between working and reporting "Invalid struct
+    /// operation". Exact field-set matches come first, then supersets, each
+    /// group ordered by name.
+    fn struct_types_matching_fields(&self, field_names: &[String]) -> Vec<String> {
+        let mut exact: Vec<&String> = Vec::new();
+        let mut superset: Vec<&String> = Vec::new();
+        for (type_name, type_def) in &self.types {
+            let TypeDef::Struct(struct_def) = type_def else {
+                continue;
+            };
+            let crate::ast::StructFields::Named(def_fields) = &struct_def.fields else {
+                continue;
+            };
+            if !field_names
+                .iter()
+                .all(|f| def_fields.iter().any(|d| &d.name.name == f))
+            {
+                continue;
+            }
+            if def_fields.len() == field_names.len() {
+                exact.push(type_name);
+            } else {
+                superset.push(type_name);
+            }
+        }
+        exact.sort();
+        superset.sort();
+        exact.into_iter().chain(superset).cloned().collect()
     }
 
     /// Find the operator impl that applies to these operands, if any.
@@ -8002,13 +8049,29 @@ impl Interpreter {
         // If calling a qualified function (Type::method), set current_self_type
         let type_name_for_self = if let Expr::Path(path) = func_expr {
             if path.segments.len() >= 2 {
-                // First segment is the type name
-                let first = &path.segments[0].ident.name;
-                // Check if it's a type name (exists in types registry)
-                if self.types.contains_key(first) {
-                    Some(first.clone())
+                // The type is everything before the final segment, which is
+                // `Type` in `Type·assoc` but `module·Type` in
+                // `module·Type·assoc`. Testing only the first segment left
+                // `Self` unbound for the qualified form, so a `Self { .. }` in
+                // the callee produced a struct literally named "Self".
+                let prefix = &path.segments[..path.segments.len() - 1];
+                let bare = &prefix[prefix.len() - 1].ident.name;
+                if self.types.contains_key(bare) {
+                    // The bare name in preference to the qualified one: it is
+                    // what an unqualified call binds, and what impl methods and
+                    // operator impls are filed under.
+                    Some(bare.clone())
                 } else {
-                    None
+                    let qualified = prefix
+                        .iter()
+                        .map(|s| s.ident.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join("·");
+                    if self.types.contains_key(&qualified) {
+                        Some(qualified)
+                    } else {
+                        None
+                    }
                 }
             } else {
                 None
@@ -13390,53 +13453,40 @@ impl Interpreter {
                         let field_names: Vec<String> = fields.borrow().keys().cloned().collect();
 
                         // Search through registered types to find a matching struct
-                        for (type_name, type_def) in &self.types {
-                            if let TypeDef::Struct(struct_def) = type_def {
-                                let def_fields: Vec<String> = match &struct_def.fields {
-                                    crate::ast::StructFields::Named(fs) => {
-                                        fs.iter().map(|f| f.name.name.clone()).collect()
-                                    }
-                                    _ => continue,
-                                };
+                        for type_name in self.struct_types_matching_fields(&field_names) {
+                            let qualified_name = format!("{}·{}", type_name, method.name);
+                            let func = self
+                                .globals
+                                .borrow()
+                                .get(&qualified_name)
+                                .map(|v| v.clone());
+                            if let Some(func) = func {
+                                if let Value::Function(f) = func {
+                                    let f = Self::wrap_with_const_generics(&f, fields);
+                                    // Set current Self type for Self { ... } resolution
+                                    let old_self_type = self.current_self_type.take();
+                                    self.current_self_type = Some(type_name.clone());
 
-                                // Match if our fields exist in the definition
-                                let matches = field_names.iter().all(|f| def_fields.contains(f));
-                                if matches {
-                                    let qualified_name = format!("{}·{}", type_name, method.name);
-                                    let func = self
-                                        .globals
-                                        .borrow()
-                                        .get(&qualified_name)
-                                        .map(|v| v.clone());
-                                    if let Some(func) = func {
-                                        if let Value::Function(f) = func {
-                                            let f = Self::wrap_with_const_generics(&f, fields);
-                                            // Set current Self type for Self { ... } resolution
-                                            let old_self_type = self.current_self_type.take();
-                                            self.current_self_type = Some(type_name.clone());
+                                    // Reorder named args to match function params (skip first param which is self)
+                                    let reordered = if f.params.len() > 1 {
+                                        Self::reorder_named_args(
+                                            &f.params[1..].to_vec(),
+                                            arg_entries.clone(),
+                                        )?
+                                    } else {
+                                        arg_values.clone()
+                                    };
+                                    let mut all_args = vec![recv.clone()];
+                                    all_args.extend(reordered);
+                                    let result = self.call_function(&f, all_args);
 
-                                            // Reorder named args to match function params (skip first param which is self)
-                                            let reordered = if f.params.len() > 1 {
-                                                Self::reorder_named_args(
-                                                    &f.params[1..].to_vec(),
-                                                    arg_entries.clone(),
-                                                )?
-                                            } else {
-                                                arg_values.clone()
-                                            };
-                                            let mut all_args = vec![recv.clone()];
-                                            all_args.extend(reordered);
-                                            let result = self.call_function(&f, all_args);
-
-                                            // Restore old Self type
-                                            self.current_self_type = old_self_type;
-                                            return result;
-                                        } else if let Value::BuiltIn(b) = func {
-                                            let mut all_args = vec![recv.clone()];
-                                            all_args.extend(arg_values.clone());
-                                            return (b.func)(self, all_args);
-                                        }
-                                    }
+                                    // Restore old Self type
+                                    self.current_self_type = old_self_type;
+                                    return result;
+                                } else if let Value::BuiltIn(b) = func {
+                                    let mut all_args = vec![recv.clone()];
+                                    all_args.extend(arg_values.clone());
+                                    return (b.func)(self, all_args);
                                 }
                             }
                         }
@@ -17674,54 +17724,40 @@ impl Interpreter {
                     let field_names: Vec<String> = fields.borrow().keys().cloned().collect();
 
                     // Search through registered types to find a matching struct
-                    for (type_name, type_def) in &self.types {
-                        if let TypeDef::Struct(struct_def) = type_def {
-                            // Check if field names match
-                            let def_fields: Vec<String> = match &struct_def.fields {
-                                crate::ast::StructFields::Named(fs) => {
-                                    fs.iter().map(|f| f.name.name.clone()).collect()
-                                }
-                                _ => continue,
-                            };
+                    for type_name in self.struct_types_matching_fields(&field_names) {
+                        let qualified_name = format!("{}·{}", type_name, method.name);
+                        let func = self
+                            .globals
+                            .borrow()
+                            .get(&qualified_name)
+                            .map(|v| v.clone());
+                        if let Some(func) = func {
+                            if let Value::Function(f) = func {
+                                let f = Self::wrap_with_const_generics(&f, fields);
+                                // Set current Self type for Self { ... } resolution
+                                let old_self_type = self.current_self_type.take();
+                                self.current_self_type = Some(type_name.clone());
 
-                            // Rough match - if we have fields that exist in the definition
-                            let matches = field_names.iter().all(|f| def_fields.contains(f));
-                            if matches {
-                                let qualified_name = format!("{}·{}", type_name, method.name);
-                                let func = self
-                                    .globals
-                                    .borrow()
-                                    .get(&qualified_name)
-                                    .map(|v| v.clone());
-                                if let Some(func) = func {
-                                    if let Value::Function(f) = func {
-                                        let f = Self::wrap_with_const_generics(&f, fields);
-                                        // Set current Self type for Self { ... } resolution
-                                        let old_self_type = self.current_self_type.take();
-                                        self.current_self_type = Some(type_name.clone());
+                                // Reorder named args to match function params (skip first param which is self)
+                                let reordered = if f.params.len() > 1 {
+                                    Self::reorder_named_args(
+                                        &f.params[1..].to_vec(),
+                                        arg_entries.clone(),
+                                    )?
+                                } else {
+                                    arg_values.clone()
+                                };
+                                let mut all_args = vec![recv.clone()];
+                                all_args.extend(reordered);
+                                let result = self.call_function(&f, all_args);
 
-                                        // Reorder named args to match function params (skip first param which is self)
-                                        let reordered = if f.params.len() > 1 {
-                                            Self::reorder_named_args(
-                                                &f.params[1..].to_vec(),
-                                                arg_entries.clone(),
-                                            )?
-                                        } else {
-                                            arg_values.clone()
-                                        };
-                                        let mut all_args = vec![recv.clone()];
-                                        all_args.extend(reordered);
-                                        let result = self.call_function(&f, all_args);
-
-                                        // Restore old Self type
-                                        self.current_self_type = old_self_type;
-                                        return result;
-                                    } else if let Value::BuiltIn(b) = func {
-                                        let mut all_args = vec![recv.clone()];
-                                        all_args.extend(arg_values.clone());
-                                        return (b.func)(self, all_args);
-                                    }
-                                }
+                                // Restore old Self type
+                                self.current_self_type = old_self_type;
+                                return result;
+                            } else if let Value::BuiltIn(b) = func {
+                                let mut all_args = vec![recv.clone()];
+                                all_args.extend(arg_values.clone());
+                                return (b.func)(self, all_args);
                             }
                         }
                     }
@@ -26756,6 +26792,57 @@ mod tests {
                 ⤺ p·scaled(2.0);
             }";
         assert!(matches!(run(source), Ok(Value::Float(v)) if v == 6.0));
+    }
+
+    #[test]
+    fn an_associated_function_reached_through_its_scroll_binds_self() {
+        // #104. `Self` was bound only when the *first* path segment named a
+        // type, which is true of `P·new(…)` but not of `geom·P·new(…)`. Left
+        // unbound, the `Self { x }` inside the constructor built a struct
+        // named, literally, "Self" -- and nothing is filed under that name, so
+        // the next operator on the value reported "Invalid struct operation".
+        let source = "\
+            scroll geom {
+                ☉ Σ P { ☉ x: f32 }
+                ⊢ P { ☉ rite new(x: f32) -> Self { Self { x } } }
+                ⊢ Add ∀ P {
+                    type Output = Self;
+                    rite add(self, o: Self) -> Self { Self·new(self.x + o.x) }
+                }
+            }
+            rite main() {
+                ≔ a = geom·P·new(1.5);
+                ⤺ (a + a).x;
+            }";
+        assert!(matches!(run(source), Ok(Value::Float(v)) if v == 3.0));
+    }
+
+    #[test]
+    fn a_self_named_value_recovers_the_same_type_on_every_run() {
+        // The other half of #104, and the part that made it a 40%-of-runs
+        // flake rather than an outright failure. A value that still ends up
+        // named `Self` is recovered by matching its field names against every
+        // registered struct; that walked `self.types`, a HashMap, and took the
+        // first hit, so two same-shaped types made the winner a per-process
+        // coin flip -- and only one of them carried the operator impl.
+        //
+        // Exact field-set matches must come first, supersets after, each group
+        // ordered by name.
+        let interp = interp_after(
+            "\
+            ☉ Σ P { ☉ x: f32 }
+            ☉ Σ Q { ☉ x: f32 }
+            ☉ Σ R { ☉ x: f32, ☉ y: f32 }
+            rite main() { ⤺ 0; }",
+        );
+        let matches = interp.struct_types_matching_fields(&["x".to_string()]);
+        assert_eq!(
+            matches
+                .iter()
+                .filter(|n| matches!(n.as_str(), "P" | "Q" | "R"))
+                .collect::<Vec<_>>(),
+            vec!["P", "Q", "R"]
+        );
     }
 
     /// The scroll every #95 test resolves against: a type reached through an


### PR DESCRIPTION
Closes #104 (does not auto-close — this targets `develop`).

`run-dir` alternated between the right answer and `[R0000] Invalid struct
operation` on the same directory with the same binary, ~40% of runs. Two
defects compose; neither reproduces alone, which is why the minimal two-file
case in the issue came back 12/12 identical.

## 1. Trigger — `Self` is not bound through a module-qualified call

`type_name_for_self` (`eval_call`) read the type out of the **first** path
segment:

```rust
let first = &path.segments[0].ident.name;
if self.types.contains_key(first) { Some(first.clone()) } else { None }
```

Right for `P·new(…)`; wrong for `geom·P·new(…)`, where segment 0 is the scroll.
`Self` stayed unbound, so the `Self { .. }` literal in the callee fell back to
its raw name and the constructor returned a struct named, literally, `"Self"`.

`lookup_operator_impl` keys operator impls by the value's struct name, and
nothing is filed under `"Self"` — so the next `+` reported
`Invalid struct operation`. This half is deterministic.

## 2. Nondeterminism — recovering a `"Self"`-named value walked a `HashMap`

A `"Self"`-named value is recovered by matching its field names against every
registered struct. Both copies of that scan iterated `self.types` — a `HashMap`
— and returned on the first hit. The match is a *subset* test, so `{x}` matches
every struct with an `x`. With more than one candidate, the recovered type (and
so the name of whatever the method returns) changed per process.

That is the coin flip.

## Reproducer

```sigil
// shapes.sg — two structs of the same shape, one with an operator impl
☉ Σ P { ☉ x: f32 }
⊢ P {
    ☉ rite new(x: f32) -> Self { Self { x } }
    ☉ rite twice(self) -> Self { Self·new(self.x * 2.0) }
}
⊢ Add ∀ P {
    type Output = Self;
    rite add(self, o: Self) -> Self { Self·new(self.x + o.x) }
}
☉ Σ Q { ☉ x: f32 }
⊢ Q {
    ☉ rite new(x: f32) -> Self { Self { x } }
    ☉ rite twice(self) -> Self { Self·new(self.x * 2.0) }
}

// main.sg
☉ rite main() -> !i32 {
    ≔ a = shapes·P·new(1.0);   // (1) returns a struct named "Self"
    ≔ b = a·twice();           // (2) recovered as P, shapes·P, Q or shapes·Q
    ≔ c = b + b;               // succeeds only when (2) landed on P
    println(c·x);
    ⤺ 0;
}
```

Instrumented, the scan chose `P`, `shapes·P`, `Q` and `shapes·Q` across runs of
the same directory. Before: **8 passes in 20 runs**. After: **30 in 30**.

The same fix makes the reported aether case stable —
`vector·Vec3·new(…)` → `·normalize()` → `+` is now 12/12 identical and correct.

## The fix

- `type_name_for_self` takes the type from the path *prefix* (everything before
  the final segment), preferring its bare last segment — the name an
  unqualified call binds, and the name impl methods and operator impls are
  filed under — falling back to the fully qualified prefix.
- Both recovery scans go through a new `struct_types_matching_fields`, which
  returns candidates in a stable order: exact field-set matches first, then
  supersets, each group sorted by name.
- The enum-variant suffix scan in `eval_path` had the same shape (first hit
  while walking `self.types`) and is collected and sorted the same way.

Fixing only the trigger would leave the coin flip in place for any other route
to a `"Self"`-named value; fixing only the scan would make the failure
deterministic rather than absent.

This is entirely in name resolution — no parser guard was touched. Consistent
with `docs/findings/middledot-module-path-vs-method-call.md`, which is why the
`geom·P·new` path already parses as a path (its rule 4).

## Ruled out (recorded so it is not re-checked)

- **File iteration order.** `run_directory` sorts lib-first / main-last,
  consistently for those cases.
- **Impl-registry order.** `generic_impls`, `concrete_impls` and the
  `operator_impls` candidate lists are all `Vec`s.

## Tests

Baseline measured on `develop` (c6ef995) first, same machine, same flags:

| | develop | this branch |
|---|---|---|
| `RUST_MIN_STACK=33554432 cargo test --release --no-fail-fast` (lib) | 569 passed / 2 failed | **571 passed / 2 failed** |
| bin | 41 passed / 0 failed | 41 passed / 0 failed |
| `jormungandr/tests/run_tests_rust.sh` | 797 passed / 4 failed / 2 skipped | 797 passed / 4 failed / 2 skipped |

The 2 unit failures are the pre-existing
`llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}`; the 4 suite
failures are the Kafka/AMQP broker tests. Identical on both sides.

Two regression tests added. `an_associated_function_reached_through_its_scroll_binds_self`
was confirmed to fail on unmodified `develop` before being kept.

`docs/findings/run-dir-nondeterminism-self-named-values.md` records the
mechanism, the reproducer and the general rule: a `HashMap` may not decide name
resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcjF6FPweMf1gk7DYXLkWC
