### PR TITLE
fix(cli): run-dir loads a directory's modules without running its entry point

### DIFF
--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -647,6 +647,16 @@ fn run_file(path: &str, program_args: &[String], skip_typecheck: bool) -> ExitCo
     }
 }
 
+/// Where a file sits in a directory's load order: the tome's interface, then
+/// its other modules, then the entry point.
+fn load_rank(name: &str) -> u8 {
+    match name {
+        "lib.sigil" | "lib.sg" => 0,
+        "main.sigil" | "main.sg" => 2,
+        _ => 1,
+    }
+}
+
 /// Run all .sg/.sigil files in a directory as a multi-module program
 fn run_directory(dir_path: &str, program_args: &[String]) -> ExitCode {
     use std::path::Path;
@@ -670,16 +680,17 @@ fn run_directory(dir_path: &str, program_args: &[String]) -> ExitCode {
     // 1. lib.sigil first (defines the module's public interface)
     // 2. Other modules in alphabetical order
     // 3. main.sigil last (uses definitions from other modules)
+    //
+    // Ranked rather than matched pairwise. The pairwise form answered `Less`
+    // to both `cmp("lib.sg", "lib.sigil")` and `cmp("lib.sigil", "lib.sg")`,
+    // and `Greater` to both directions of the `main.*` pair, which is not a
+    // total order -- `sort_by` is allowed to panic on one.
     files.sort_by(|a, b| {
         let a_name = Path::new(a).file_name().and_then(|n| n.to_str()).unwrap_or("");
         let b_name = Path::new(b).file_name().and_then(|n| n.to_str()).unwrap_or("");
-        match (a_name, b_name) {
-            ("lib.sigil", _) | ("lib.sg", _) => std::cmp::Ordering::Less,
-            (_, "lib.sigil") | (_, "lib.sg") => std::cmp::Ordering::Greater,
-            ("main.sigil", _) | ("main.sg", _) => std::cmp::Ordering::Greater,
-            (_, "main.sigil") | (_, "main.sg") => std::cmp::Ordering::Less,
-            _ => a_name.cmp(b_name),
-        }
+        load_rank(a_name)
+            .cmp(&load_rank(b_name))
+            .then_with(|| a_name.cmp(b_name))
     });
 
     if files.is_empty() {
@@ -762,8 +773,13 @@ fn run_directory(dir_path: &str, program_args: &[String]) -> ExitCode {
             }
         };
 
-        // Execute to register all definitions
-        if let Err(e) = interpreter.execute(&ast) {
+        // Register this file's definitions *without* running the entry point.
+        // `execute` looks `main` up in the globals rather than in the file it
+        // was handed, so once any file had defined it, every later file's load
+        // ran it again -- and `call_main` below then ran it once more. A
+        // directory of N modules invoked `main` N+1 times, repeating every side
+        // effect it performed.
+        if let Err(e) = interpreter.execute_definitions(&ast) {
             eprintln!("Error loading '{}': {}", file_path, e);
             return ExitCode::from(1);
         }
@@ -8687,3 +8703,80 @@ mod collision_corpus_tests {
     }
 }
 
+#[cfg(test)]
+mod run_directory_tests {
+    use super::load_rank;
+    use sigil_parser::interpreter::{Interpreter, Value};
+    use sigil_parser::parser::Parser;
+
+    fn parse(source: &str) -> sigil_parser::ast::SourceFile {
+        Parser::new(source).parse_file().expect("parse")
+    }
+
+    #[test]
+    fn load_order_ranks_the_interface_first_and_the_entry_point_last() {
+        assert_eq!(load_rank("lib.sg"), 0);
+        assert_eq!(load_rank("lib.sigil"), 0);
+        assert_eq!(load_rank("vector.sg"), 1);
+        assert_eq!(load_rank("main.sg"), 2);
+        assert_eq!(load_rank("main.sigil"), 2);
+    }
+
+    #[test]
+    fn the_load_order_comparator_is_a_total_order() {
+        // The pairwise `match (a_name, b_name)` it replaced answered `Less` to
+        // both directions of ("lib.sg", "lib.sigil") and `Greater` to both
+        // directions of the `main.*` pair, because each hit the same arm
+        // whichever way round it was asked. `sort_by` is allowed to panic on a
+        // comparator like that.
+        let names = [
+            "lib.sg",
+            "lib.sigil",
+            "main.sg",
+            "main.sigil",
+            "vector.sg",
+            "bounds.sigil",
+        ];
+        let cmp = |a: &str, b: &str| load_rank(a).cmp(&load_rank(b)).then_with(|| a.cmp(b));
+        for a in names {
+            assert_eq!(cmp(a, a), std::cmp::Ordering::Equal, "{a} vs itself");
+            for b in names {
+                assert_eq!(
+                    cmp(a, b),
+                    cmp(b, a).reverse(),
+                    "asymmetric for ({a}, {b})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn loading_a_module_does_not_run_the_entry_point() {
+        // `run_directory` loads every file and then calls `main` itself.
+        // `execute` looks `main` up in the globals rather than in the file it
+        // was handed, so once any file had defined it every later load ran it
+        // again: N modules produced N+1 invocations, repeating every side
+        // effect. Loading has to register and nothing more.
+        let entry = "☉ rite main() -> !i32 { ⤺ 7; }";
+
+        // `execute` runs it, and hands back what it returned.
+        let mut ran = Interpreter::new();
+        assert!(
+            matches!(ran.execute(&parse(entry)), Ok(Value::Int(7))),
+            "execute is expected to invoke main -- if this changed, \
+             run_directory's reason for not using it changed too"
+        );
+
+        // `execute_definitions` must not, on the entry file or on a sibling
+        // loaded after it.
+        let mut loaded = Interpreter::new();
+        assert!(matches!(
+            loaded.execute_definitions(&parse(entry)),
+            Ok(Value::Null)
+        ));
+        assert!(matches!(
+            loaded.execute_definitions(&parse("☉ rite other() -> i32 { 1 }")),
+            Ok(Value::Null)
+        ));
+    }
+}


### PR DESCRIPTION
Closes #107 (does not auto-close — this targets `develop`).

### Rebase note

Rebased twice: first onto `f9bafb6` (was 14 behind), then onto `aa3d039`
(9 behind) as `develop` kept moving. The **second rebase applied cleanly** — no
conflict. The first had one, in `parser/src/main.rs`,
and it was mine on both sides: this branch appends `mod run_directory_tests` at
the end of the file, and #133/#135 landed `mod collision_corpus_tests` in the
same place. Two independent `#[cfg(test)]` modules, neither replacing the
other — **both kept**, nothing else in the conflict region. The functional
hunks (`execute_definitions`, the hoisted `load_rank`) applied cleanly.

Re-verified after the rebase rather than assuming: the N-file table below still
holds, and #128's nested-module resolution still works on top of it (a
`tui/{mod,grid,vterm,layout}.sg` + `tui/widgets/button.sg` tree runs correctly).

## Cause

`Interpreter::execute` (`interpreter.rs:3110`) does not only execute the file it
is handed. After running the file's items it looks `main` up **in the globals**
and calls it:

```rust
for item in &file.items {
    result = self.execute_item(&item.node)?;
}

let main_fn = self.globals.borrow().get("main")…;
if let Some(f) = main_fn {
    if f.params.is_empty() {
        result = self.call_function(&f, vec![])?;
    }
}
```

Because it looks in the globals rather than in the file, once *any* file has
registered `main`, every later `execute` runs it again. `run_directory` called
`execute` once per file and then `call_main` — hence N + 1.

`execute_definitions` (`interpreter.rs:3138`) is exactly `execute` minus the
auto-call, and its doc comment already says "Use this when loading files as part
of a multi-file workspace". The workspace loader (`main.rs:978`, `main.rs:1148`),
the module loader and the stdlib loader all use it. `run_directory` was the one
caller left on `execute`.

## Second defect in the same function

The load-order comparator matched name pairs:

```rust
match (a_name, b_name) {
    ("lib.sigil", _) | ("lib.sg", _) => Ordering::Less,
    (_, "lib.sigil") | (_, "lib.sg") => Ordering::Greater,
    ("main.sigil", _) | ("main.sg", _) => Ordering::Greater,
    (_, "main.sigil") | (_, "main.sg") => Ordering::Less,
    _ => a_name.cmp(b_name),
}
```

`cmp("lib.sg", "lib.sigil")` and `cmp("lib.sigil", "lib.sg")` both hit arm 1 and
both return `Less`; both directions of the `main.*` pair hit arm 3 and both
return `Greater`. That is not a total order, and `slice::sort_by` is documented
as permitted to panic on one. Replaced with a rank — interface 0, modules 1,
entry point 2 — and the file name as tie-break.

This is *not* what made #104 flake; the ordering it produced was still
deterministic.

## Measured

`app.sg` plus N−1 inert modules that define nothing used, counting how often
`main`'s `println` fires:

| files in dir | before | after | expected |
|---|---|---|---|
| 1 | 2 | **1** | 1 |
| 2 | 3 | **1** | 1 |
| 3 | 4 | **1** | 1 |
| 4 | 5 | **1** | 1 |
| 5 | 6 | **1** | 1 |

A directory holding both `main.sg` and `main.sigil` ran `main` three times
before; once now.

## Tests

Baseline measured on `develop` (c6ef995) first, same machine, same flags:

Rebased again onto `develop` @ `aa3d039`. Re-measured on both sides:

| | develop @ aa3d039 | this branch |
|---|---|---|
| `RUST_MIN_STACK=33554432 cargo test --release --no-fail-fast` (lib) | 586 passed / 2 failed | 586 passed / 2 failed |
| bin | 46 passed / 0 failed | **49 passed / 0 failed** |
| `jormungandr/tests/run_tests_rust.sh` | 801 / 4 failed / 2 skipped | 801 / 4 failed / 2 skipped |
| morgoth `run_tests.sh` @ `adad4cf` | — | 239 / 0 |

The 2 unit failures are the pre-existing
`llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}`; the 4 suite
failures are the Kafka/AMQP broker tests. Identical on both sides.

Three tests added. `loading_a_module_does_not_run_the_entry_point` pins both
halves of the contract `run_directory` now depends on — that `execute` *does*
invoke `main` (so a future change there does not silently reintroduce this) and
that `execute_definitions` does not, neither on the entry file nor on a sibling
loaded after it. The two ordering tests document the total-order property rather
than reproducing the old comparator, which was inline and is gone.

Independent of #116 (#104): different file, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcjF6FPweMf1gk7DYXLkWC