### PR TITLE
fix(typeck): resolve Self to the implementing type for primitive impls

### DIFF
--- a/jormungandr/tests/spec/25_nihil_gaps/test_self_in_primitive_impl.sg
+++ b/jormungandr/tests/spec/25_nihil_gaps/test_self_in_primitive_impl.sg
@@ -1,0 +1,97 @@
+// Test: `Self` inside a trait impl for a primitive or reference type
+// Issue: sigil-lang#108 (Lares capability probe, gap S125)
+// Priority: P1 - blocks the Sigil-primitive → JS-value boundary in Qliphoth
+//
+// Purpose:
+// `⊢ Trait ∀ f64` must bind `Self` to the primitive `f64`. It used to bind it
+// to `Named("f64")`, which has no unify arm against `Type::Float(F64)`, so
+// every use of `self` in the body failed against its own type:
+//
+//     type mismatch in argument 1: expected F64!, found f64!
+//
+// For `bool` the two render identically, which is why the original report read
+// as nonsense — "expected bool!, found bool!". A reference target was worse:
+// `∀ &str` is not a `TypeExpr::Path`, so the impl type resolved to the literal
+// string "Unknown".
+//
+// The regression this pins is a *type* check, so the assertions below are
+// incidental — the test fails at check time if the gap reopens.
+//
+// Expected behavior:
+// All assertions pass; the file type-checks.
+
+Θ Describe {
+    rite describe(self: Self!) -> i64!;
+}
+
+rite take_bool(b: bool!) -> i64! { ⎇ b { 1 } ⎉ { 0 } }
+rite take_f64(n: f64!) -> i64! { ⎇ n > 0.0 { 1 } ⎉ { 0 } }
+rite take_i32(n: i32!) -> i64! { ⎇ n > 0 { 1 } ⎉ { 0 } }
+rite take_u32(n: u32!) -> i64! { ⎇ n > 0 { 1 } ⎉ { 0 } }
+rite take_str(s: &str!) -> i64! { ⎇ s == "" { 0 } ⎉ { 1 } }
+
+⊢ Describe ∀ bool {
+    rite describe(self: Self!) -> i64! { take_bool(self) }
+}
+
+⊢ Describe ∀ f64 {
+    rite describe(self: Self!) -> i64! { take_f64(self) }
+}
+
+⊢ Describe ∀ i32 {
+    rite describe(self: Self!) -> i64! { take_i32(self) }
+}
+
+⊢ Describe ∀ u32 {
+    rite describe(self: Self!) -> i64! { take_u32(self) }
+}
+
+⊢ Describe ∀ &str {
+    rite describe(self: Self!) -> i64! { take_str(self) }
+}
+
+// A named type must keep resolving exactly as before — this is the control,
+// and it is the path the fix deliberately leaves untouched.
+Σ Wrap { x: i64! }
+rite take_wrap(w: Wrap!) -> i64! { 1 }
+
+⊢ Describe ∀ Wrap {
+    rite describe(self: Self!) -> i64! { take_wrap(self) }
+}
+
+rite test_primitive_impls() {
+    ≔ b: bool = true;
+    assert_eq(take_bool(b), 1);
+
+    ≔ f: f64 = 2.5;
+    assert_eq(take_f64(f), 1);
+
+    ≔ i: i32 = 7;
+    assert_eq(take_i32(i), 1);
+
+    ≔ u: u32 = 7;
+    assert_eq(take_u32(u), 1);
+
+    println("  PASS: test_primitive_impls");
+}
+
+rite test_reference_impl() {
+    assert_eq(take_str("hello"), 1);
+    assert_eq(take_str(""), 0);
+    println("  PASS: test_reference_impl");
+}
+
+rite test_named_impl_unchanged() {
+    ≔ w = Wrap { x: 1 };
+    assert_eq(take_wrap(w), 1);
+    println("  PASS: test_named_impl_unchanged");
+}
+
+☉ rite main() -> !i32 {
+    println("=== S125: Self inside a primitive trait impl ===");
+    test_primitive_impls();
+    test_reference_impl();
+    test_named_impl_unchanged();
+    println("All Self-in-primitive-impl tests passed!");
+    ⤺ 0;
+}

--- a/parser/src/typeck.rs
+++ b/parser/src/typeck.rs
@@ -1494,10 +1494,23 @@ impl TypeChecker {
                     }
                 }
 
-                // Set current_self_type with generics so Self resolves correctly
-                self.current_self_type = Some(Type::Named {
-                    name: type_name.clone(),
-                    generics: generic_types,
+                // `⊢ Trait ∀ f64` must bind `Self` to the primitive `f64`, not to
+                // `Named("f64")`. The two have no unify arm, so every use of `self`
+                // in the body failed against its own type — and for `bool` both
+                // render as "bool", giving "expected bool!, found bool!"
+                // (sigil-lang#108). A reference target was worse: `∀ &str` is not a
+                // `TypeExpr::Path` at all, so `type_path_to_name` returned the
+                // literal string "Unknown".
+                //
+                // `convert_type` already maps primitives, references and the rest.
+                // Only user-defined types come back as `Named`, and for those the
+                // name-plus-generics form below is kept exactly as it was.
+                self.current_self_type = Some(match self.convert_type(&impl_block.self_ty) {
+                    Type::Named { .. } => Type::Named {
+                        name: type_name.clone(),
+                        generics: generic_types,
+                    },
+                    primitive_or_ref => primitive_or_ref,
                 });
 
                 // Collect associated functions/methods
@@ -1655,10 +1668,23 @@ impl TypeChecker {
                     }
                 }
 
-                // Set current_self_type with generics so Self resolves correctly
-                self.current_self_type = Some(Type::Named {
-                    name: type_name,
-                    generics: generic_types,
+                // `⊢ Trait ∀ f64` must bind `Self` to the primitive `f64`, not to
+                // `Named("f64")`. The two have no unify arm, so every use of `self`
+                // in the body failed against its own type — and for `bool` both
+                // render as "bool", giving "expected bool!, found bool!"
+                // (sigil-lang#108). A reference target was worse: `∀ &str` is not a
+                // `TypeExpr::Path` at all, so `type_path_to_name` returned the
+                // literal string "Unknown".
+                //
+                // `convert_type` already maps primitives, references and the rest.
+                // Only user-defined types come back as `Named`, and for those the
+                // name-plus-generics form below is kept exactly as it was.
+                self.current_self_type = Some(match self.convert_type(&impl_block.self_ty) {
+                    Type::Named { .. } => Type::Named {
+                        name: type_name,
+                        generics: generic_types,
+                    },
+                    primitive_or_ref => primitive_or_ref,
                 });
 
                 // Check each function in the impl block


### PR DESCRIPTION
Closes #108. (`Closes` does not auto-close in this repo — I will close it by hand once this merges.)

## The defect

`⊢ Into[JsValue] ∀ f64` bound `Self` to `Named("f64")`. There is no unify arm between that and `Type::Float(F64)`, so every use of `self` in the body failed against its own type:

```
type mismatch in argument 1: expected F64!, found f64!
```

For `bool` the two render identically, which is how the original report read — `expected bool!, found bool!`. A type mismatched against itself sends the reader after a printer bug; it is the resolver. Same shape as S22, where the message also pointed at the wrong half of the type.

A reference target failed differently and worse. `∀ &str` is not a `TypeExpr::Path`, so `type_path_to_name` fell to its catch-all and returned the literal string `"Unknown"`:

```
type mismatch in argument 1: expected &str!, found Unknown!
```

## The fix

Both `current_self_type` assignment sites built `Type::Named { name, generics }` unconditionally from that string. `convert_type` already maps primitives, references, tuples and the rest correctly — it is what every other type position goes through — so the impl target now goes through it too:

```rust
self.current_self_type = Some(match self.convert_type(&impl_block.self_ty) {
    Type::Named { .. } => Type::Named { name: type_name, generics: generic_types },
    primitive_or_ref => primitive_or_ref,
});
```

Only user-defined types come back as `Named`, and **that arm is left byte-identical** — so nothing about generic or struct impls changes. That was deliberate: routing everything through `convert_type` would also have changed the bare-`Foo`-with-generic-params case, which `unify` currently accepts through its empty-generics rule, and this issue is not the place to disturb that.

Bisected in both directions before fixing: writing `bool!` in place of `Self!` is clean, and `Self!` in an impl for a struct is clean, so it is specifically `Self` × a non-`Named` target.

## Why it is worth the churn

It was the **only compiler-caused failure in Qliphoth's entire framework set** — the other twelve are unported Rust ([qliphoth#17](https://github.com/Daemoniorum-LLC/qliphoth/issues/17)). And it sits on `packages/qliphoth-sys/src/js.sigil`, the Sigil-primitive-to-JS-value boundary that every Qliphoth app passing a primitive to the host goes through.

## Validation

Each side measured, not assumed:

| | |
|---|---|
| minimal repro | exit 1 → exit 0, 3/3 runs each side |
| controls | `bool!` for `Self!`, and `Self!` over a struct — clean before and after |
| qliphoth `develop` @ `2ab768b` | **39/52 → 40/52** framework files; exactly one file changed status, `js.sigil`, and it is the intended one |
| lares-client `output/` | 101/102 before and after, **identical failure set** (the one failure is #112, unrelated) |
| `cargo test --lib` | **524 passed, 0 failed** |
| Sigil suite | **798 passed, 4 failed** |

The four suite failures are `P0_005_kafka_producer`, `P0_007_amqp`, `P1_006_kafka_consumer`, `P1_008_amqp_consumer` — all `Runtime error` from absent brokers, all environmental, none a type error.

Unit-test and suite counts are under `--features minimal,protocols`, since the default features need LLVM 18; the 885 quoted in the Lares handoff is the full feature set. Worth a CI confirmation under `jit,llvm,wasm,lsp,protocols` rather than taking my numbers as covering it.

## Regression test

`jormungandr/tests/spec/25_nihil_gaps/test_self_in_primitive_impl.sg` pins all five original error shapes — `bool`, `f64`, `i32`, `u32`, `&str` — and carries a named-type impl as a control for the arm this change deliberately does not touch. It fails to type-check on the parent commit with exactly the five errors from the issue.

## Coordination

Found by the Lares capability probe (gap **S125**). `sigil-lang` had another active session on it (`lr-adhoc-7`, `sigil-tui-support`), so I checked for overlap before starting — that worktree was at `4461b5d` with no uncommitted changes and nothing ahead of `origin/develop`, and had claimed a worktree path rather than files. Claimed `parser/src/typeck.rs` on the Lares coord-log before touching it. This work was done in a separate detached worktree off `origin/develop`; the shared `sigil-lang` checkout (on `feature/s1-sigil-web-wasm-compat`, dirty) was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LXt42yPbCnUVutXyWBfhN
