### PR TITLE
feat(interpreter): reach a module in a subdirectory of its tome

### DIFF
--- a/docs/findings/tome-module-paths-and-subdirectories.md
+++ b/docs/findings/tome-module-paths-and-subdirectories.md
@@ -1,0 +1,51 @@
+# How `invoke tome·…` finds a module file
+
+**Recorded:** 2026-09-10, closing #109.
+
+A tome used to have to be one flat directory. `invoke tome·tui·grid·{Region}`
+took the module name from the **second** segment alone, looked for `tui.sg`,
+and failed with `undefined variable: Region` — which points nowhere near the
+nesting.
+
+Subdirectories were never meant to be unreachable: the workspace loader
+(`main.rs`) has always read `router/types.sigil` as the module `router·types`
+and `router/mod.sigil` as `router`. `run` and `run-dir` simply did not.
+
+## The rule
+
+A path's segments do not say where the module stops and the imported item
+begins:
+
+```sigil
+invoke tome·analyze;              // analyze.sg
+invoke tome·output·Output;        // output.sg,      item Output
+invoke tome·tui·grid·{Region};    // tui/grid.sg,    item Region
+invoke tome·tui·{layer_name};     // tui/mod.sg,     item layer_name
+```
+
+So `resolve_tome_module` drops the `tome` root, appends the final name, and
+tries the **longest** module path first, giving up one segment at a time. For
+each candidate length it looks for, in order:
+
+```
+<path>.sigil    <path>.sg    <path>/mod.sigil    <path>/mod.sg
+```
+
+The first that names a file wins, and the module is registered under the
+`·`-joined form — `tui/grid.sg` is the module `tui·grid`, matching the
+workspace loader.
+
+Longest-first means `a/b.sg` beats `a.sg` for `tome·a·b·{…}` when both exist.
+A flat `output.sg` is still found for `tome·output·{…}`, which is the spelling
+every existing tome uses.
+
+`scroll foo;` goes through the same resolver, so a module may be a file or a
+directory with a `mod.sg` in it.
+
+## What is still flat
+
+`run-dir` lists and eagerly loads only the top level of the directory it is
+given. Modules in subdirectories load on demand, when an `invoke` or `scroll`
+reaches them — which is the Rust rule, and means an unreferenced file is not
+executed. Making `run-dir`'s eager listing recurse belongs with the load-order
+rework in #107.

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -3830,17 +3830,18 @@ impl Interpreter {
                         }
                     }
                 } else {
-                    // External module: mod foo; - try to load foo.sigil or foo.sg from same directory
+                    // External module: `scroll foo;` - foo.sigil, foo.sg, or a
+                    // directory of its own carrying foo/mod.sg, the way the
+                    // workspace loader already reads a subdirectory.
                     if let Some(ref source_dir) = self.current_source_dir {
-                        let module_path_sigil =
-                            std::path::Path::new(source_dir).join(format!("{}.sigil", module_name));
-                        let module_path_sg =
-                            std::path::Path::new(source_dir).join(format!("{}.sg", module_name));
-                        let module_path = if module_path_sigil.exists() {
-                            module_path_sigil
-                        } else {
-                            module_path_sg
-                        };
+                        let module_path = Self::resolve_tome_module(
+                            source_dir,
+                            std::slice::from_ref(&module_name),
+                        )
+                        .map(|(_, file)| std::path::PathBuf::from(file))
+                        .unwrap_or_else(|| {
+                            std::path::Path::new(source_dir).join(format!("{}.sg", module_name))
+                        });
 
                         if module_path.exists() {
                             crate::sigil_debug!(
@@ -4124,21 +4125,31 @@ impl Interpreter {
                         {
                             // Load from current source directory
                             if let Some(source_dir) = &self.current_source_dir.clone() {
-                                // Determine module name:
-                                // - invoke tome·module·Item -> prefix=["tome","module"], name=Item -> module_name = prefix[1]
-                                // - invoke tome·module -> prefix=["tome"], name=module -> module_name = name (simple_name)
-                                let module_name = if prefix.len() >= 2 {
-                                    prefix[1].clone()
-                                } else {
-                                    // `invoke tome·analyze;` case: prefix=["tome"], simple_name="analyze"
-                                    simple_name.clone()
-                                };
-                                let module_file_sigil = format!("{}/{}.sigil", source_dir, module_name);
-                                let module_file_sg = format!("{}/{}.sg", source_dir, module_name);
-                                let module_file = if std::path::Path::new(&module_file_sigil).exists() {
-                                    module_file_sigil
-                                } else {
-                                    module_file_sg
+                                // Which of the path's segments name the module,
+                                // and which name the item inside it, is not
+                                // known from the path alone:
+                                //
+                                //   invoke tome·analyze          -> analyze.sg
+                                //   invoke tome·output·Output    -> output.sg
+                                //   invoke tome·tui·greet·{greet} -> tui/greet.sg
+                                //
+                                // So try the longest module path first and give
+                                // up a segment at a time, taking the first that
+                                // names a file. Directories are addressed the
+                                // way the workspace loader already addresses
+                                // them -- `tui/greet.sg` is the module
+                                // `tui·greet`, `tui/mod.sg` is `tui`.
+                                let mut segments: Vec<String> =
+                                    prefix.iter().skip(1).cloned().collect();
+                                segments.push(simple_name.clone());
+                                let Some((module_name, module_file)) =
+                                    Self::resolve_tome_module(source_dir, &segments)
+                                else {
+                                    crate::sigil_debug!(
+                                        "DEBUG process_use_tree: no tome module file for {:?}",
+                                        segments
+                                    );
+                                    return Ok(());
                                 };
                                 crate::sigil_debug!(
                                     "DEBUG process_use_tree: loading tome module '{}' from {}",
@@ -4148,7 +4159,7 @@ impl Interpreter {
                                 // Skip if already loaded (prevent infinite recursion)
                                 if self.loaded_crates.contains(&module_file) {
                                     // Already loaded, skip
-                                } else if std::path::Path::new(&module_file).exists() {
+                                } else {
                                     // Mark as loaded before processing (handle circular deps)
                                     self.loaded_crates.insert(module_file.clone());
 
@@ -5873,6 +5884,33 @@ impl Interpreter {
                 full_name, full_name, last_name
             )))
         }
+    }
+
+    /// Find the file behind `invoke tome·a·b·…`, and the module name to load
+    /// it under.
+    ///
+    /// `segments` is the path with the `tome` root dropped and the final name
+    /// appended, longest-first: the caller cannot tell where the module path
+    /// stops and the imported item begins, so each candidate length is tried
+    /// until one names a file. A directory is spelled the way the workspace
+    /// loader spells it -- `tui/greet.sg` is the module `tui·greet` and
+    /// `tui/mod.sg` is the module `tui`.
+    fn resolve_tome_module(source_dir: &str, segments: &[String]) -> Option<(String, String)> {
+        for len in (1..=segments.len()).rev() {
+            let parts = &segments[..len];
+            let rel = parts.join("/");
+            for candidate in [
+                format!("{}/{}.sigil", source_dir, rel),
+                format!("{}/{}.sg", source_dir, rel),
+                format!("{}/{}/mod.sigil", source_dir, rel),
+                format!("{}/{}/mod.sg", source_dir, rel),
+            ] {
+                if std::path::Path::new(&candidate).is_file() {
+                    return Some((parts.join("·"), candidate));
+                }
+            }
+        }
+        None
     }
 
     /// The trait and method a binary operator dispatches to when the built-in
@@ -26843,6 +26881,123 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["P", "Q", "R"]
         );
+    }
+
+    /// A fresh directory under the system temp dir, removed when the guard
+    /// drops. Module resolution reads the filesystem, so these tests need a
+    /// tome on disk rather than a source string.
+    struct TempTome(std::path::PathBuf);
+
+    impl TempTome {
+        fn new(tag: &str) -> TempTome {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            static NEXT: AtomicUsize = AtomicUsize::new(0);
+            let n = NEXT.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "sigil-tome-{}-{}-{}",
+                tag,
+                std::process::id(),
+                n
+            ));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).expect("create temp dir");
+            TempTome(path)
+        }
+
+        fn write(&self, rel: &str, contents: &str) -> &TempTome {
+            let path = self.0.join(rel);
+            std::fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+            std::fs::write(&path, contents).expect("write module");
+            self
+        }
+
+        fn dir(&self) -> String {
+            self.0.to_string_lossy().into_owned()
+        }
+
+        /// Run `source` as the tome's entry point, with the tome on disk as the
+        /// source directory so `invoke tome·…` can reach it.
+        fn run(&self, source: &str) -> Result<Value, RuntimeError> {
+            let file = Parser::new(source)
+                .parse_file()
+                .map_err(|e| RuntimeError::new(e.to_string()))?;
+            let mut interp = Interpreter::new();
+            interp.set_current_source_dir(Some(self.dir()));
+            interp.execute(&file)
+        }
+    }
+
+    impl Drop for TempTome {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn a_module_in_a_subdirectory_is_reachable_through_its_path() {
+        // #109. `invoke tome·a·b·{…}` took the module name from the *second*
+        // segment alone, so it looked for `a.sg` and never `a/b.sg`. A tome had
+        // to be one flat directory, and the failure said only
+        // `undefined variable`, which points nowhere near the nesting.
+        let tome = TempTome::new("nested");
+        tome.write(
+            "tui/grid.sg",
+            "☉ rite area(w: i32, h: i32) -> i32 { w * h }",
+        );
+        let source = "\
+            invoke tome·tui·grid·{area};
+            rite main() { ⤺ area(4, 5); }";
+        assert!(matches!(tome.run(source), Ok(Value::Int(20))));
+    }
+
+    #[test]
+    fn a_subdirectory_speaks_for_itself_through_mod() {
+        // The workspace loader already reads `tui/mod.sg` as the module `tui`;
+        // `invoke tome·tui·{…}` has to reach the same file.
+        let tome = TempTome::new("modfile");
+        tome.write("tui/mod.sg", "☉ rite layer() -> i32 { 7 }");
+        let source = "\
+            invoke tome·tui·{layer};
+            rite main() { ⤺ layer(); }";
+        assert!(matches!(tome.run(source), Ok(Value::Int(7))));
+    }
+
+    #[test]
+    fn a_flat_module_still_resolves_beside_a_directory_of_the_same_name() {
+        // The module path is tried longest-first, so `tome·output·Output` finds
+        // `output/Output.sg` when there is one. A flat `output.sg` must still
+        // be found when there is not -- that is the spelling every existing
+        // tome uses.
+        let tome = TempTome::new("flat");
+        tome.write("output.sg", "☉ rite width() -> i32 { 3 }");
+        let source = "\
+            invoke tome·output·{width};
+            rite main() { ⤺ width(); }";
+        assert!(matches!(tome.run(source), Ok(Value::Int(3))));
+    }
+
+    #[test]
+    fn the_longest_module_path_wins() {
+        // `a.sg` and `a/b.sg` can both exist. `tome·a·b·{…}` names the deeper
+        // one; resolution gives up a segment at a time only when nothing
+        // answers.
+        let tome = TempTome::new("longest");
+        tome.write("a.sg", "☉ rite pick() -> i32 { 1 }")
+            .write("a/b.sg", "☉ rite pick() -> i32 { 2 }");
+
+        let deep = Interpreter::resolve_tome_module(
+            &tome.dir(),
+            &["a".to_string(), "b".to_string(), "pick".to_string()],
+        );
+        assert_eq!(deep.as_ref().map(|(name, _)| name.as_str()), Some("a·b"));
+        assert!(deep.unwrap().1.ends_with("a/b.sg"));
+
+        let shallow =
+            Interpreter::resolve_tome_module(&tome.dir(), &["a".to_string(), "pick".to_string()]);
+        assert_eq!(shallow.as_ref().map(|(name, _)| name.as_str()), Some("a"));
+        assert!(shallow.unwrap().1.ends_with("a.sg"));
+
+        assert!(Interpreter::resolve_tome_module(&tome.dir(), &["nope".to_string()]).is_none());
     }
 
     /// The scroll every #95 test resolves against: a type reached through an


### PR DESCRIPTION
Closes #109 (does not auto-close — this targets `develop`).

## Not an intentional constraint

The issue asks whether flat-only is by design. It is not: the **workspace
loader has always supported nesting**. `main.rs`, loading a crate's `src/`:

```rust
// e.g., "analyze.sigil" -> module name "analyze"
//       "router/mod.sigil" -> module name "router"
//       "router/types.sigil" -> module name "router·types"
```

`run` and `run-dir` simply never implemented it. `invoke tome·tui·grid·{Region}`
took the module name from the **second** segment alone:

```rust
let module_name = if prefix.len() >= 2 { prefix[1].clone() } else { simple_name.clone() };
let module_file_sg = format!("{}/{}.sg", source_dir, module_name);
```

so it looked for `tui.sg`, found nothing, and left the import unresolved —
surfacing as `undefined variable: Region`, which points nowhere near the
nesting.

## The rule

A path's segments do not say where the module stops and the imported item
begins — these are all the same shape:

```sigil
invoke tome·analyze;              // analyze.sg
invoke tome·output·Output;        // output.sg,   item Output
invoke tome·tui·grid·{Region};    // tui/grid.sg, item Region
invoke tome·tui·{layer_name};     // tui/mod.sg,  item layer_name
```

So `resolve_tome_module` drops the `tome` root, appends the final name, and
tries the **longest** module path first, giving up a segment at a time. At each
length it looks for `<path>.sigil`, `<path>.sg`, `<path>/mod.sigil`,
`<path>/mod.sg`, and the first that names a file wins. The module registers
under the `·`-joined form — `tui/grid.sg` is `tui·grid` — matching the workspace
loader.

`scroll foo;` was routed through the same resolver, so a module may be a file
**or** a directory carrying a `mod.sg`.

## Verified against the shape morgoth needs

```
nest2/
├── main.sg
├── app.sg
└── tui/
    ├── mod.sg
    └── grid.sg
```

```sigil
// tui/grid.sg
☉ Σ Region { ☉ w: i32, ☉ h: i32 }
⊢ Region { ☉ rite new(w: i32, h: i32) -> Self { Self { w, h } } }
☉ rite area(r: Region) -> i32 { r·w * r·h }

// app.sg
invoke tome·tui·grid·{Region, area};
☉ rite describe() -> i32 { area(Region·new(4, 5)) }

// main.sg
invoke tome·app·{describe};
invoke tome·tui·{layer_name};
☉ rite main() -> !i32 { println(layer_name()); println(describe()); ⤺ 0; }
```

On `develop` @ `c6ef995`: `undefined variable`. Here, under both `sigil run
./main.sg` and `sigil run-dir .`:

```
tui
20
```

Types and free functions both cross the directory boundary.

## Compatibility

Longest-first means `a/b.sg` beats `a.sg` for `tome·a·b·{…}` when both exist —
which is what the deeper spelling asks for. A flat `output.sg` is still found
for `tome·output·{…}`, the spelling every existing tome uses;
`a_flat_module_still_resolves_beside_a_directory_of_the_same_name` covers it,
and the 797-test Jormungandr suite (all flat tomes) is unchanged.

## What is still flat

`run-dir` lists and eagerly loads only the top level of the directory it is
given. Modules in subdirectories load on demand, when an `invoke` or `scroll`
reaches them — which is the Rust rule, and means an unreferenced file is not
executed. Making `run-dir`'s eager listing recurse touches the same function as
#119 (#107), so it belongs there rather than here.

## Tests

Baseline measured on `develop` (c6ef995) first, same machine, same flags:

Rebased onto `develop` after #116 merged (5df25eb), so the baseline moved from
569 to 571 lib tests.

| | develop @ 5df25eb | this branch |
|---|---|---|
| `RUST_MIN_STACK=33554432 cargo test --release --no-fail-fast` (lib) | 571 passed / 2 failed | **575 passed / 2 failed** |
| bin | 41 passed / 0 failed | 41 passed / 0 failed |
| `jormungandr/tests/run_tests_rust.sh` | 797 / 4 failed / 2 skipped | 797 / 4 failed / 2 skipped |

The 2 unit failures are the pre-existing
`llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}`; the 4 suite
failures are the Kafka/AMQP broker tests. Identical on both sides.

Four tests added, three of them end-to-end against a tome written to a temp
directory (module resolution reads the filesystem, so a source string cannot
exercise it). The two nesting cases were confirmed failing on a `develop` build
before the change — with exactly the `undefined variable` the issue reports.

`docs/findings/tome-module-paths-and-subdirectories.md` records the resolution
order and the four spellings.

Rebased on top of #116 (#104), and independent of #119 (#107): #119 touches `run_directory` in
`main.rs`, this touches module resolution in `interpreter.rs`. #116 and this one
both touch `interpreter.rs` but in unrelated regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcjF6FPweMf1gk7DYXLkWC