### PR TITLE
test(migrate): a harness for the reserved-name corpus claim

### DIFF
--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -8483,3 +8483,71 @@ mod migrate_destination_tests {
         assert_eq!(fs::read_to_string(&src).unwrap(), RUST_SOURCE);
     }
 }
+
+/// The committed corpus behind the reserved-name diagnostic.
+///
+/// #68 is sold on a corpus property -- "0 false positives across N files" --
+/// that nothing on the branch reproduced, so every change to the scanner
+/// re-established it by hand and no two hand-built sweeps were comparable
+/// (#90). `tools/collision-sweep/sweep.sh` is the wide measurement; this is
+/// the per-PR check: four files, one per shape the scanner has been wrong
+/// about, with their findings pinned exactly.
+///
+/// A scanner change that alters any expectation below has to change it here,
+/// in the same commit, where a reviewer sees it.
+#[cfg(test)]
+mod collision_corpus_tests {
+    use super::collect_keyword_collisions;
+
+    fn findings(fixture: &str) -> Vec<(String, usize)> {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../tools/collision-sweep/corpus")
+            .join(fixture);
+        let source = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        collect_keyword_collisions(&source)
+    }
+
+    fn expect(fixture: &str, want: &[(&str, usize)]) {
+        let got = findings(fixture);
+        let got: Vec<(&str, usize)> = got.iter().map(|(n, c)| (n.as_str(), *c)).collect();
+        assert_eq!(got, want, "findings for {fixture}");
+    }
+
+    #[test]
+    fn a_name_is_judged_by_its_position_not_by_itself() {
+        // `tome` is a valid Sigil field and an invalid binding; `this` is the
+        // other way round. Both appear in both positions in the fixture, so a
+        // scanner with one verdict per word fails this whichever way it
+        // decides: only the parameter `tome` and the field `this` are refused.
+        expect("positions.rs", &[("this", 1), ("tome", 1)]);
+    }
+
+    #[test]
+    fn a_closure_parameter_is_a_binding() {
+        // #84/#89. `this` binds cleanly, so no closure parameter spelled
+        // `this` may be reported -- develop carried exactly that as a live
+        // false positive, in cranelift-isle and rustc-demangle. `of` is
+        // refused in every position, so it is a true positive and stays.
+        //
+        // `tome` is counted once: the typed `|mut tome: u32|` is found by its
+        // colon. The untyped `|mut tome|` beside it is #91 -- a quiet false
+        // negative, in the same direction as #84.
+        expect("closure_params.rs", &[("of", 1), ("tome", 1)]);
+    }
+
+    #[test]
+    fn prose_is_not_code() {
+        // Prose ends a sentence with a colon too. Reading comments reported
+        // every colon-terminated word in a doc comment as a field.
+        expect("prose.rs", &[]);
+    }
+
+    #[test]
+    fn a_where_bound_is_not_a_field() {
+        // `where Self: Sized` inside a trait body reads exactly like a field
+        // declaration.
+        expect("bounds.rs", &[]);
+    }
+}
+

--- a/tools/collision-sweep/README.md
+++ b/tools/collision-sweep/README.md
@@ -1,0 +1,76 @@
+# Reserved-name collision sweep
+
+The reserved-name diagnostic (#68) rests on a corpus property: **no false
+positives**. That property was a memory, not a measurement — no harness on the
+branch reproduced the original 6,091-file number, so every change to the
+scanner re-established it by hand, and two hand-built sweeps (21,897 registry
+files one way, a 2,500-file sample the other) were comparable neither to each
+other nor to the original (#90).
+
+There are two things here, and they answer different questions.
+
+## The per-PR check — `corpus/`
+
+Four files, one per shape the scanner has been wrong about, with their findings
+pinned **exactly** in `collision_corpus_tests` (`parser/src/main.rs`). Runs in
+milliseconds as part of `cargo test`.
+
+| fixture | the shape | why |
+|---|---|---|
+| `positions.rs` | one name in two positions | `tome` is a valid field and an invalid binding; `this` is the reverse |
+| `closure_params.rs` | closure parameters | #84/#89 — develop carried `\|this\|` as a live false positive |
+| `prose.rs` | colons in comments | "Implementation based on:" is not a field |
+| `bounds.rs` | `where Self: Sized` | reads exactly like a field declaration |
+
+A scanner change that alters any expectation has to change it in the same
+commit, where a reviewer sees it. That is the point: the property becomes a
+check rather than a memory.
+
+## The wide measurement — `sweep.sh`
+
+```console
+$ ./sweep.sh ~/.cargo/registry/src -o /tmp/sweep-before
+sweep: 31464 files under /home/…/.cargo/registry/src
+…
+files with findings: 76
+findings (rows):     80
+distinct names:      12
+```
+
+Writes into the output directory:
+
+| file | |
+|---|---|
+| `manifest.txt` | root, file count, digest of the sorted relative path list, sha256 of the binary |
+| `findings.tsv` | `relative/path` ⇥ `name` ⇥ `uses`, sorted |
+| `summary.txt` | the headline counts, and names ranked by files affected |
+| `raw.err` | the `migrate` stderr the report was parsed from |
+
+**The corpus and the build are reported, not assumed.** "The crate registry"
+is not reproducible across machines or months; a file count plus a digest of
+the relative path list is. `sigil` has no `--version`, so the binary is
+recorded by sha256 — a path and a timestamp do not say which code ran, which is
+the whole question a before/after comparison is asking. `compare.sh` says so
+loudly when two sweeps scanned different file sets, and notes when they used
+the same binary.
+
+## Comparing two builds
+
+```console
+$ git checkout develop && (cd parser && cargo build --release)
+$ ./sweep.sh ~/.cargo/registry/src -o /tmp/sweep-before
+$ git checkout my-branch && (cd parser && cargo build --release)
+$ ./sweep.sh ~/.cargo/registry/src -o /tmp/sweep-after
+$ ./compare.sh /tmp/sweep-before /tmp/sweep-after
+```
+
+Exit 0 means no new findings. Exit 1 lists them, and each one has to be argued
+for: a new row is either the true positive the change set out to find, or the
+regression it did not. Rows that *disappear* are fixed false positives.
+
+## The trap
+
+`sigil migrate` can rewrite files in place. `sweep.sh` only ever runs
+`--dry-run`, which since #92/#94 writes nothing anywhere — that is what makes
+it safe to point at `~/.cargo/registry`. An in-place sweep there corrupts the
+cargo cache. Do not add a mode to this script that writes.

--- a/tools/collision-sweep/compare.sh
+++ b/tools/collision-sweep/compare.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Diff two sweeps and fail on anything new.
+#
+# This is what makes "0 false positives" a check rather than a memory: run
+# sweep.sh on develop, run it again on the branch, and compare. Every new row
+# has to be argued for. A change that only *removes* rows is a fixed false
+# positive; a change that adds them is either the true positive it set out to
+# find, or the regression it did not.
+#
+# Usage:
+#   compare.sh <before-dir> <after-dir>
+#
+# Exit codes:
+#   0  no new findings
+#   1  new findings (listed on stdout)
+#   2  usage or input error
+
+set -euo pipefail
+
+die() { echo "compare: $*" >&2; exit 2; }
+
+[ $# -eq 2 ] || die "usage: compare.sh <before-dir> <after-dir>"
+before="$1/findings.tsv"
+after="$2/findings.tsv"
+[ -f "$before" ] || die "no findings.tsv in $1"
+[ -f "$after" ]  || die "no findings.tsv in $2"
+
+# The two sweeps have to have looked at the same files, or the diff means
+# nothing. Compare what each recorded scanning.
+bd=$(awk '/^path-digest:/ {print $2}' "$1/manifest.txt" 2>/dev/null || true)
+ad=$(awk '/^path-digest:/ {print $2}' "$2/manifest.txt" 2>/dev/null || true)
+if [ -n "$bd" ] && [ -n "$ad" ] && [ "$bd" != "$ad" ]; then
+    echo "compare: WARNING -- the two sweeps scanned different file sets" >&2
+    echo "  before: $(awk '/^files:/ {print $2}' "$1/manifest.txt") files, digest $bd" >&2
+    echo "  after:  $(awk '/^files:/ {print $2}' "$2/manifest.txt") files, digest $ad" >&2
+    echo "  the counts below are not comparable" >&2
+fi
+
+# Two sweeps by the same binary compare a build against itself, which is not
+# what anyone runs this for.
+bb=$(awk '/^binary-sha256:/ {print $2}' "$1/manifest.txt" 2>/dev/null || true)
+ab=$(awk '/^binary-sha256:/ {print $2}' "$2/manifest.txt" 2>/dev/null || true)
+if [ -n "$bb" ] && [ "$bb" = "$ab" ]; then
+    echo "compare: note -- both sweeps used the same binary ($bb)" >&2
+fi
+
+added=$(LC_ALL=C comm -13 "$before" "$after" || true)
+removed=$(LC_ALL=C comm -23 "$before" "$after" || true)
+
+n_added=$([ -z "$added" ] && echo 0 || printf '%s\n' "$added" | wc -l)
+n_removed=$([ -z "$removed" ] && echo 0 || printf '%s\n' "$removed" | wc -l)
+
+echo "before: $(wc -l < "$before") findings"
+echo "after:  $(wc -l < "$after") findings"
+echo "added:   $n_added"
+echo "removed: $n_removed"
+
+if [ "$n_removed" -gt 0 ]; then
+    echo
+    echo "removed (no longer reported):"
+    printf '%s\n' "$removed" | sed 's/^/  - /'
+fi
+
+if [ "$n_added" -gt 0 ]; then
+    echo
+    echo "ADDED (each of these needs an argument):"
+    printf '%s\n' "$added" | sed 's/^/  + /'
+    exit 1
+fi
+
+echo
+echo "no new findings"

--- a/tools/collision-sweep/corpus/README.md
+++ b/tools/collision-sweep/corpus/README.md
@@ -1,0 +1,13 @@
+# The committed corpus
+
+Four files, one per shape the scanner has been wrong about. They exist so the
+reserved-name property is checked on every PR in milliseconds, rather than
+re-argued from a wide sweep nobody reruns.
+
+`collision_corpus_findings_are_exactly_these` in `parser/src/main.rs` asserts
+the **exact** findings for each file. A change to the scanner that alters any
+of them has to change the expectation too, in the same commit, where a reviewer
+sees it.
+
+The wide sweep (`../sweep.sh`) is the evidence for a corpus-scale claim. This is
+the regression test.

--- a/tools/collision-sweep/corpus/bounds.rs
+++ b/tools/collision-sweep/corpus/bounds.rs
@@ -1,0 +1,15 @@
+// A `where` bound puts a name in front of a colon inside a trait body, which
+// otherwise reads exactly like a field declaration.
+
+pub trait Sized2 {
+    fn probe(&self)
+    where
+        Self: Sized;
+}
+
+pub trait Bounded<T>
+where
+    T: Clone,
+{
+    fn get(&self) -> T;
+}

--- a/tools/collision-sweep/corpus/closure_params.rs
+++ b/tools/collision-sweep/corpus/closure_params.rs
@@ -1,0 +1,30 @@
+// #84/#89: a closure parameter is a binding, not a field. `this` binds
+// cleanly in Sigil, so none of these may be reported -- develop carried this
+// as a live false positive, found in cranelift-isle and rustc-demangle.
+
+pub fn untyped() -> u32 {
+    let f = |this| this;
+    f(1)
+}
+
+pub fn typed() -> u32 {
+    let f = |this: u32| this;
+    f(2)
+}
+
+pub fn several() -> u32 {
+    let f = |this, of| this + of;
+    f(1, 2)
+}
+
+// #91: `mut` between the bar and the name. The byte before the name is the
+// `t` of `mut`, so the untyped test does not see it, and there is no colon.
+pub fn with_mut() -> u32 {
+    let f = |mut tome| { tome += 1; tome };
+    f(3)
+}
+
+pub fn with_mut_typed() -> u32 {
+    let f = |mut tome: u32| { tome += 1; tome };
+    f(4)
+}

--- a/tools/collision-sweep/corpus/positions.rs
+++ b/tools/collision-sweep/corpus/positions.rs
@@ -1,0 +1,16 @@
+// One name, two positions, opposite verdicts. `tome` is a valid Sigil field
+// and an invalid binding; `this` is the other way round. A scanner with one
+// verdict per word gets one of these wrong whichever way it decides.
+
+pub struct Doc {
+    pub tome: String,
+    pub this: u32,
+}
+
+pub fn load(tome: &str) -> usize {
+    tome.len()
+}
+
+pub fn read(this: u32) -> u32 {
+    this
+}

--- a/tools/collision-sweep/corpus/prose.rs
+++ b/tools/collision-sweep/corpus/prose.rs
@@ -1,0 +1,15 @@
+// Prose ends a sentence with a colon too. None of the words below is a field,
+// and reading comments as code reported every one of them.
+
+/// Implementation based on:
+///   tome: the containing volume
+///   of: the preposition
+//
+// Continue mobbing if:
+//   ref: still contended
+pub struct Empty;
+
+pub fn documented() -> &'static str {
+    // super: not a field either
+    "of: still not a field"
+}

--- a/tools/collision-sweep/sweep.sh
+++ b/tools/collision-sweep/sweep.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Sweep a tree of Rust sources for reserved-name collisions and write a stable,
+# diffable report.
+#
+# The reserved-name diagnostic (#68) is sold on a corpus property -- "0 false
+# positives across N files". #90: nothing on the branch reproduced that number,
+# so every change to the scanner re-established it by hand, and two hand-built
+# sweeps are comparable neither to each other nor to the original. This is the
+# harness that makes it a measurement.
+#
+# Usage:
+#   sweep.sh <corpus-root> [-o <out-dir>] [--sigil <binary>]
+#
+# Writes into <out-dir> (default ./sweep-out):
+#   manifest.txt  what was actually scanned -- root, file count, digest
+#   findings.tsv  one row per (file, name): relative-path <TAB> name <TAB> uses
+#   summary.txt   the headline counts
+#   raw.err       the migrate stderr the report was parsed from
+#
+# NEVER runs a mode that writes. `--dry-run` (#92/#94) writes nothing anywhere,
+# which is what makes it safe to point at ~/.cargo/registry -- an earlier
+# in-place sweep there would have corrupted the cargo cache.
+
+set -euo pipefail
+
+die() { echo "sweep: $*" >&2; exit 2; }
+
+root=""
+out="sweep-out"
+sigil=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -o|--out)   out="${2:-}"; shift 2 || die "-o needs a directory" ;;
+        --sigil)    sigil="${2:-}"; shift 2 || die "--sigil needs a path" ;;
+        -h|--help)  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -*)         die "unknown option: $1" ;;
+        *)          [ -z "$root" ] || die "one corpus root at a time"; root="$1"; shift ;;
+    esac
+done
+
+[ -n "$root" ] || die "usage: sweep.sh <corpus-root> [-o <out-dir>] [--sigil <binary>]"
+[ -d "$root" ] || die "not a directory: $root"
+
+if [ -z "$sigil" ]; then
+    here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    sigil="$here/../../parser/target/release/sigil"
+fi
+[ -x "$sigil" ] || die "no sigil binary at $sigil (build with: cd parser && cargo build --release)"
+
+mkdir -p "$out"
+out="$(cd "$out" && pwd)"
+root_abs="$(cd "$root" && pwd)"
+
+# What was scanned, so the number in a claim can be checked rather than
+# remembered. "the crate registry" is not reproducible across machines or
+# months; a file count and a digest of the sorted path list is.
+echo "sweep: taking the manifest..." >&2
+find "$root_abs" -name '*.rs' -type f | LC_ALL=C sort > "$out/files.txt"
+file_count=$(wc -l < "$out/files.txt")
+[ "$file_count" -gt 0 ] || die "no .rs files under $root_abs"
+digest=$(sed "s|^$root_abs/||" "$out/files.txt" | LC_ALL=C sha256sum | cut -d' ' -f1)
+
+# The build is recorded the same way the corpus is: by digest. `sigil` has no
+# --version, and a path plus a timestamp does not say which code ran -- which
+# is the whole question a before/after comparison is asking.
+sigil_digest=$(sha256sum "$sigil" | cut -d' ' -f1)
+
+{
+    echo "root:         $root_abs"
+    echo "files:        $file_count"
+    echo "path-digest:  $digest"
+    echo "binary:       $sigil"
+    echo "binary-sha256: $sigil_digest"
+    echo "swept:        $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} > "$out/manifest.txt"
+
+echo "sweep: $file_count files under $root_abs" >&2
+
+# --dry-run writes nothing. stdout is the diff preview and is discarded; the
+# collision warnings go to stderr, one block per file, and name their file.
+set +e
+"$sigil" migrate "$root_abs" --dry-run > /dev/null 2> "$out/raw.err"
+rc=$?
+set -e
+[ "$rc" -le 1 ] || die "migrate exited $rc; see $out/raw.err"
+
+# Parse the warning blocks into rows. A block is
+#     warning: <path>: N names are refused ...:
+#         <name>          <count> uses
+# and the report is sorted so two sweeps diff cleanly.
+awk -v root="$root_abs/" '
+    /^warning: .*: [0-9]+ name/ {
+        line = $0
+        sub(/^warning: /, "", line)
+        # strip the trailing ": N name(s) ... :" -- the path may contain ": "
+        # nowhere on disk, but match the last occurrence to be safe
+        idx = match(line, /: [0-9]+ name(s)? (is|are) refused/)
+        path = substr(line, 1, idx - 1)
+        sub("^" root, "", path)
+        next
+    }
+    /^    [^ ]/ && path != "" {
+        name = $1
+        uses = $2
+        print path "\t" name "\t" uses
+    }
+    /^  Rename them/ { path = "" }
+' "$out/raw.err" | LC_ALL=C sort > "$out/findings.tsv"
+
+files_with=$(cut -f1 "$out/findings.tsv" | LC_ALL=C sort -u | wc -l)
+names=$(cut -f2 "$out/findings.tsv" | LC_ALL=C sort -u | wc -l)
+rows=$(wc -l < "$out/findings.tsv")
+uses=$(awk -F'\t' '{s += $3} END {print s + 0}' "$out/findings.tsv")
+
+{
+    cat "$out/manifest.txt"
+    echo
+    echo "files with findings: $files_with"
+    echo "findings (rows):     $rows"
+    echo "distinct names:      $names"
+    echo "total uses:          $uses"
+    echo
+    echo "names by files affected:"
+    cut -f2 "$out/findings.tsv" | LC_ALL=C sort | uniq -c | sort -rn | head -40
+} > "$out/summary.txt"
+
+cat "$out/summary.txt"
+echo >&2
+echo "sweep: wrote $out/{manifest.txt,findings.tsv,summary.txt,raw.err}" >&2


### PR DESCRIPTION
Closes #90 (does not auto-close — this targets `develop`).

Two things, answering different questions. The issue asks for a committed
harness, a *defined* corpus, and something cheap enough to run per PR — those
are not the same artefact, so this is two.

## The per-PR check — `tools/collision-sweep/corpus/`

Four files, one per shape the scanner has been wrong about, with their findings
pinned **exactly** in `collision_corpus_tests` (`parser/src/main.rs`).
Milliseconds, inside `cargo test`.

| fixture | shape | why it is there |
|---|---|---|
| `positions.rs` | one name in two positions | `tome` is a valid field and an invalid binding; `this` is the reverse — a scanner with one verdict per word fails this whichever way it decides |
| `closure_params.rs` | closure parameters | #84/#89 — develop carried `\|this\|` as a **live** false positive |
| `prose.rs` | colons in comments | "Implementation based on:" is not a field |
| `bounds.rs` | `where Self: Sized` | reads exactly like a field declaration |

Expectations are the literal finding lists, e.g.

```rust
expect("positions.rs", &[("this", 1), ("tome", 1)]);
expect("prose.rs", &[]);
```

A scanner change that alters one has to change it in the same commit, where a
reviewer sees it. That is what turns the property from a memory into a check.

## The wide measurement — `sweep.sh` / `compare.sh`

```console
$ ./sweep.sh ~/.cargo/registry/src -o /tmp/sweep-before
sweep: 31464 files under /home/…/.cargo/registry/src
…
files with findings: 76
findings (rows):     80
distinct names:      12
```

Output is `manifest.txt` (root, file count, **digest of the sorted relative
path list**, binary), `findings.tsv` (`path` ⇥ `name` ⇥ `uses`, sorted),
`summary.txt`, and the `raw.err` it was parsed from.

The corpus is **reported, not assumed** — the issue's point that "the crate
registry" is not reproducible across machines or months is exactly right, so
the harness records what it actually scanned. `compare.sh` warns loudly when
two sweeps' digests differ, and otherwise diffs findings, exiting 1 on any new
row:

```console
$ ./compare.sh /tmp/sweep-before /tmp/sweep-after
before: 4 findings
after:  5 findings
added:   1
removed: 0

ADDED (each of these needs an argument):
  + closure_params.rs	tome	2
```

Every added row is either the true positive a change set out to find or the
regression it did not. Rows that disappear are fixed false positives.

## What it measures today

develop @ `5df25eb`, 31,464 files under `~/.cargo/registry/src`: **76 files
with findings, 80 rows, 12 distinct names** (`aspect` 29, `simd` 20, `this` 12,
`ref` 6, `of` 4, then a tail).

I spot-checked all 12 `this` findings, since `this` is the name #84/#89 was
about. Every one is a **struct field**:

```rust
this: &'a mut ThinArc<H, T>,   // triomphe-0.1.15/src/thin_arc.rs
this: V2,                      // pulp-0.22.2/src/x86/v2.rs
this: &'a TokenStream,         // logos-codegen-0.14.4/src/generator/mod.rs
```

`this` is refused as a field and accepted as a binding, so these are true
positives — the closure-parameter false positive #89 fixed is gone, and what
remains under that name is correct. That is the kind of claim that was not
checkable before.

## The trap, encoded

`sweep.sh` only ever runs `--dry-run`, which since #92/#94 writes nothing
anywhere — that is what makes it safe to point at `~/.cargo/registry`. The
README says not to add a writing mode, and the script has no flag that could
select one.

## Tests

Baseline measured on `develop` (5df25eb) first, same machine, same flags:

| | develop | this branch |
|---|---|---|
| `RUST_MIN_STACK=33554432 cargo test --release --no-fail-fast` (lib) | 571 passed / 2 failed | 571 passed / 2 failed |
| bin | 41 passed / 0 failed | **45 passed / 0 failed** |

The 2 failures are the pre-existing
`llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}`.

This is the blocker #91 names. #91 follows on top of this branch, with a
before/after sweep as its evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcjF6FPweMf1gk7DYXLkWC
