### PR TITLE
fix(migrate): judge a closure parameter written `|mut x|`

### DIFF
--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -6000,6 +6000,10 @@ struct CollisionScan {
     /// The last non-whitespace byte, for `!` before a bracket and `$` before a
     /// word.
     prev_byte: u8,
+    /// The byte before the *previous* word, so a name behind a `mut` can still
+    /// be seen to start a closure parameter: in `|mut tome|` the byte before
+    /// `tome` is the `t` of `mut`, and the bar is one word further back.
+    prev_word_before: u8,
 }
 
 /// Tally names in one span of code that the parser refuses where they stand.
@@ -6014,6 +6018,7 @@ fn collect_in_code(
         prev_words,
         in_where,
         prev_byte,
+        prev_word_before,
     } = state;
     // Everything above carries over from the previous span deliberately: a
     // comment is not a syntactic break, so `let /* why */ x: T` is still a
@@ -6115,8 +6120,16 @@ fn collect_in_code(
             // parameter named after its own type; the byte before it is the
             // `:`, so it is not. `|x: &'a Tome|` fails the same test on the
             // `a` of the lifetime.
+            // `|mut tome|` starts a parameter one word further back: the byte
+            // before the name is the `t` of `mut`, so the test has to look
+            // past it to the bar or comma before *that*. The typed
+            // `|mut tome: u32|` was already caught by its colon, which is what
+            // made the untyped form a quiet false negative rather than a
+            // visible one.
+            let starts_a_param = matches!(before, b'|' | b',')
+                || (prev_words[1] == "mut" && matches!(*prev_word_before, b'|' | b','));
             let untyped_closure_param = in_closure_params
-                && matches!(before, b'|' | b',')
+                && starts_a_param
                 && matches!(rest.as_bytes().first(), Some(b',') | Some(b'|'));
             if (untyped_closure_param || (rest.starts_with(':') && !rest.starts_with("::")))
                 && !*in_where
@@ -6132,6 +6145,7 @@ fn collect_in_code(
                 }
             }
             *prev_byte = bytes[i - 1];
+            *prev_word_before = before;
             if word == "where" {
                 *in_where = true;
             }
@@ -8052,6 +8066,50 @@ mod migrate_span_tests {
     }
 
     #[test]
+    fn a_mut_closure_parameter_is_still_a_parameter() {
+        // #91. A closure parameter is found either by the colon in `|x: T|`
+        // or, untyped, by starting and ending one -- the byte before it is the
+        // bar or a comma, and a comma or the closing bar follows. `|mut tome|`
+        // satisfies neither: the byte before `tome` is the `t` of `mut`, and
+        // there is no colon. A quiet false negative in the same direction as
+        // #84 -- a name that is fine as a field and refused as a binding went
+        // unwarned.
+        let f = |src: &str| super::collect_keyword_collisions(src);
+
+        assert_eq!(
+            f("fn g() { let f = |mut tome| tome; }"),
+            vec![("tome".into(), 1)]
+        );
+        // The typed form always worked; its colon finds it.
+        assert_eq!(
+            f("fn g() { let f = |mut tome: u32| tome; }"),
+            vec![("tome".into(), 1)]
+        );
+        // Not only after the opening bar.
+        assert_eq!(
+            f("fn g() { let f = |a, mut tome| a; }"),
+            vec![("tome".into(), 1)]
+        );
+        assert_eq!(
+            f("fn g() { let f = move |mut tome| tome; }"),
+            vec![("tome".into(), 1)]
+        );
+        // `mut` reaches back exactly one word, and only to a bar or a comma.
+        // A type is still not a name: the word before `u32` is `mut`, but what
+        // precedes that `mut` is a colon.
+        assert!(f("fn g() { let f = |x: mut u32| x; }").is_empty());
+        // A binding the parser accepts stays unreported, `mut` or not --
+        // `this` is the direction #84/#89 was about.
+        assert!(f("fn g() { let f = |mut this| this; }").is_empty());
+        // Outside a parameter list `mut` reaches nothing: a local is judged by
+        // `let mut`, not by this.
+        assert_eq!(
+            f("fn g() { let mut tome: u32 = 1; }"),
+            vec![("tome".into(), 1)]
+        );
+    }
+
+    #[test]
     fn a_bar_that_is_not_a_parameter_list_is_left_alone() {
         let f = |src: &str| super::collect_keyword_collisions(src);
 
@@ -8530,10 +8588,11 @@ mod collision_corpus_tests {
         // false positive, in cranelift-isle and rustc-demangle. `of` is
         // refused in every position, so it is a true positive and stays.
         //
-        // `tome` is counted once: the typed `|mut tome: u32|` is found by its
-        // colon. The untyped `|mut tome|` beside it is #91 -- a quiet false
-        // negative, in the same direction as #84.
-        expect("closure_params.rs", &[("of", 1), ("tome", 1)]);
+        // `tome` is counted twice: once for the typed `|mut tome: u32|`,
+        // found by its colon, and once for the untyped `|mut tome|` beside it.
+        // The untyped form was #91 -- the byte before the name is the `t` of
+        // `mut`, so the test had to look one word further back for the bar.
+        expect("closure_params.rs", &[("of", 1), ("tome", 2)]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #91.

#133 (#90) has landed, and this is retargeted to `develop` — it was stacked on
that branch because #91's own text says the blocker is that there is no harness
to re-check the sweep with. The harness commit is now in `develop`, so this is
one commit.

## The gap

A closure parameter is found either by the colon in `|x: T|` or, untyped, by
*starting* and *ending* one — the byte before it is the bar or a comma, and a
comma or the closing bar follows:

```rust
let untyped_closure_param = in_closure_params
    && matches!(before, b'|' | b',')
    && matches!(rest.as_bytes().first(), Some(b',') | Some(b'|'));
```

`|mut tome|` satisfies neither: the byte before `tome` is the `t` of `mut`, and
there is no colon. `|mut tome: u32|` was always caught — by its colon — which
is what made the untyped form a *quiet* false negative rather than a visible
one.

## The fix

`mut` reaches back exactly one word, so the test looks past it to the bar or
comma before *that*:

```rust
let starts_a_param = matches!(before, b'|' | b',')
    || (prev_words[1] == "mut" && matches!(*prev_word_before, b'|' | b','));
```

`prev_words` already carried the word; `prev_word_before` on `CollisionScan` is
the one byte it did not. The clause stays gated by `in_closure_params`, so
nothing outside a parameter list moves — a local is still judged by `let mut`,
not by this, and a test is included for that.

## The sweep #91 asked for

> Do not fix it without re-checking the sweep.

Both halves of the #133 harness, run either side of this commit.

**Committed corpus** — exactly the intended change and nothing else:

```console
$ ./compare.sh /tmp/corpus-before /tmp/corpus-after
removed (no longer reported):
  - closure_params.rs	tome	1
ADDED (each of these needs an argument):
  + closure_params.rs	tome	2
```

`tome` goes from 1 use to 2: the untyped `|mut tome|` beside the typed one is
now judged. The expectation in `collision_corpus_tests` changed with it, in
this commit.

**Wide sweep** — `~/.cargo/registry/src`, 31,464 files, identical path digest
either side, so directly comparable:

```console
$ ./compare.sh /tmp/sweep-before /tmp/sweep-final
before: 80 findings
after:  80 findings
added:   0
removed: 0

no new findings
```

**0 added, 0 removed.** No new false positives — and no new true positives in
real crates either, which is consistent with the note already on
`a_closure_parameter_is_a_binding_not_a_field` that a 21,897-file re-sweep
found no reserved name used as a closure parameter in this direction. That half
is now *measured and absent* rather than unmeasured, which is the difference
#90 was for.

## Tests

Baseline measured on `develop` (5df25eb) first, same machine, same flags:

| | develop | #133 | this branch |
|---|---|---|---|
| `cargo test --release` (lib) | 571 / 2 failed | 571 / 2 failed | 571 / 2 failed |
| bin | 41 / 0 | 45 / 0 | **46 / 0** |

The 2 failures are the pre-existing
`llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}`.

`a_mut_closure_parameter_is_still_a_parameter` covers the untyped and typed
forms, the second-parameter position, `move |mut …|`, and the two directions it
must *not* move: `|x: mut u32|` (the word before `u32` is `mut`, but a colon
precedes that `mut`) and `|mut this|` (a binding the parser accepts — the #84/#89
direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcjF6FPweMf1gk7DYXLkWC