### PR TITLE
fix(typeck): let comparison coerce int to float, as argument and arithmetic already do

### DIFF
--- a/jormungandr/tests/spec/25_nihil_gaps/test_int_float_comparison.sg
+++ b/jormungandr/tests/spec/25_nihil_gaps/test_int_float_comparison.sg
@@ -1,0 +1,72 @@
+// Test: an integer literal compared against a float
+// Issue: sigil-lang#112 (Lares capability probe, gap S127)
+// Priority: P1
+//
+// Purpose:
+// `x ≥ 70` where `x: f64` used to be a type error while `take_f64(0)` and
+// `x + 70` — the same coercion, in argument and arithmetic position — were both
+// already accepted. Comparison was the only position that refused it.
+//
+// The three forms below must agree. They are written together deliberately:
+// the defect was not that any one of them was wrong, but that they disagreed,
+// and a rule applied in two places out of three is the kind of thing that reads
+// as correct in every individual review.
+//
+// This surfaced through the React→Sigil migration, where it looks like a
+// migrator defect: JS has one numeric type, so a `number` prop becomes `f64`
+// while its literals become `I64`. Emitting those literals as floats instead
+// was measured over the 102-component Lares corpus and took compilation from
+// 101 to 90 — `.len() > 0` is a `USize` against a float. The literals were
+// never the problem.
+//
+// Expected behavior:
+// All assertions pass; the file type-checks.
+
+rite take_f64(n: f64!) -> i64! { ⎇ n > 0.0 { 1 } ⎉ { 0 } }
+
+rite test_argument_position() {
+    // Already legal before the fix.
+    assert_eq(take_f64(0), 0);
+    assert_eq(take_f64(3), 1);
+    println("  PASS: test_argument_position");
+}
+
+rite test_arithmetic_position() {
+    // Already legal before the fix.
+    ≔ x: f64 = 0.5;
+    ≔ y = x + 70;
+    assert(y > 70.0, "0.5 + 70 should exceed 70");
+    println("  PASS: test_arithmetic_position");
+}
+
+rite test_comparison_position() {
+    // The one that used to be rejected, in both operand orders.
+    ≔ x: f64 = 80.5;
+    assert(x ≥ 70, "80.5 >= 70");
+    assert((x > 70), "80.5 > 70");
+    assert(70 ≤ x, "70 <= 80.5 — int on the left");
+    assert((70 < x), "70 < 80.5 — int on the left");
+
+    ≔ low: f64 = 0.5;
+    assert((low < 40), "0.5 < 40");
+    println("  PASS: test_comparison_position");
+}
+
+rite test_integers_still_compare_as_integers() {
+    // The coercion must not disturb int-to-int comparison, which is what
+    // `.len() > 0` relies on everywhere.
+    ≔ n = 5;
+    assert((n > 0), "5 > 0");
+    assert(n ≤ 5, "5 <= 5");
+    println("  PASS: test_integers_still_compare_as_integers");
+}
+
+☉ rite main() -> !i32 {
+    println("=== S127: int literal against a float ===");
+    test_argument_position();
+    test_arithmetic_position();
+    test_comparison_position();
+    test_integers_still_compare_as_integers();
+    println("All int/float comparison tests passed!");
+    ⤺ 0;
+}

--- a/parser/src/typeck.rs
+++ b/parser/src/typeck.rs
@@ -3157,12 +3157,30 @@ impl TypeChecker {
                 };
                 // For bootstrapping: skip error when either side is a type variable or function
                 // (indicates incomplete type inference from unhandled expressions)
+                // An int literal against a float is already allowed everywhere
+                // else: `take_f64(0)` passes the argument coercion, and `x + 70`
+                // passes the arithmetic one. Only comparison rejected it, so
+                // `x ≥ 70` was an error while `x + 70` beside it was fine.
+                //
+                // That inconsistency is what #112 actually is. It reads as a
+                // migrator defect — JS has one numeric type, so a `number` prop
+                // becomes `f64` while its literals become `I64` — but emitting
+                // those literals as floats instead is worse: measured over the
+                // 102-component Lares corpus it took compilation from 101 to 90,
+                // because `.len() > 0` is a `USize` against a float. The
+                // literals were never the problem; the asymmetry was.
+                //
+                // Directional in both orders, reusing the argument rule so there
+                // is one definition of "int may become float".
+                let numeric_coercion = Self::is_numeric_coercion(&left_inner, &right_inner)
+                    || Self::is_numeric_coercion(&right_inner, &left_inner);
                 if !self.unify(&left_inner, &right_inner)
                     && !is_var_or_fn(&left_inner)
                     && !is_var_or_fn(&right_inner)
                     && !has_unit(&left_inner, &right_inner)
                     && !both_int(&left_inner, &right_inner)
                     && !has_named(&left_inner, &right_inner)
+                    && !numeric_coercion
                 {
                     self.error(TypeError::new(format!(
                         "comparison operands must have same type: left={:?}, right={:?}",


### PR DESCRIPTION
Closes #112 — but **not the way #112 proposes**, and not in the file it points at.

## The actual defect

`x ≥ 70` where `x: f64` was a type error. The identical coercion in the two other positions was already accepted:

| | | |
|---|---|---|
| `take_f64(0)` | argument | **already legal** |
| `x + 70` | arithmetic | **already legal** |
| `x ≥ 70` | comparison | **rejected** |

The comparison arm carried escape hatches for type variables, unit, named types and int-against-int, and no arm for the numeric coercion the rest of the checker already performs. It now reuses `is_numeric_coercion` in both operand orders, so there is one definition of "an int may become a float" instead of two places that agree and a third that does not.

A rule applied in two positions out of three is exactly the kind of thing that reads as correct in every individual review.

## Why I did not fix the migrator, having first tried to

#112 (mine) says this is a `sigil migrate` defect, and the reasoning is sound as far as it goes: JS has one numeric type, so a `number` prop becomes `f64` while its literals come out as `I64`, and `Math.min(100, score * 100)` becomes `math_min(100, score * 100)`.

So I built that fix — emit every JS numeric literal as a Sigil float, since JS numbers *are* IEEE-754 doubles. Then I measured it against the 102-component Lares corpus:

| | compiling |
|---|---|
| `develop` today | 101 / 102 |
| **migrator emits float literals** | **90 / 102** |
| **comparison coercion (this PR)** | **102 / 102** |

Every one of the twelve new failures was the same thing: `.len() > 0`, a `USize` against a float. The literals were never the problem — the asymmetry was, and floatifying literals just moved the mismatch to a different pair of types.

I am reporting the discarded attempt because the plausible fix was measurably worse than the status quo, and nothing about reading the code would have told me that.

With the migrator untouched, the corpus reaches **102 compiling / 0 failing** and links (363,152 bytes).

## Validation

| | |
|---|---|
| three positions agree | argument, arithmetic and comparison all accept it, in both operand orders |
| int-to-int unaffected | `.len() > 0` still compares as integers — the thing the 12 regressions were about |
| Lares corpus | 101/102 → **102/102**, project links |
| `cargo test --lib` | **905 passed, 0 failed** |
| Sigil suite | **798 passed, 4 failed** — the four known Kafka/AMQP broker failures |

Counts under `--features minimal,protocols,react-migrate,wasm`.

## Interaction with #130 — please read before merging either

The negative case added in #130 used *this comparison* as its rejected program, since it was the reproduction for #114. This change makes that program legal, so the test would have quietly stopped being a negative test.

Already handled: #130 now uses bool-against-int, which has no coercion path in any position, and I verified it exits 1 under builds of **both** branches. Nothing further is needed, but the two should not be reviewed as independent.

That interaction is itself an instance of sigil-lang#131 — a test that keeps passing after it has stopped testing anything is a green light that changed the question it was answering.

## Judgement call for review

This makes Sigil slightly more permissive, and #124 records that strictness here is partly deliberate. My argument is that this PR does not add permissiveness, it removes an inconsistency — the coercion already exists and is already applied in two of three positions. If the preferred direction is the other way, the fix would be to remove it from argument and arithmetic position too, which would be a much larger and more disruptive change and should not be decided by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LXt42yPbCnUVutXyWBfhN
