### PR TITLE
fix(interpreter): resolve `scroll` from the file that declares it

### DIFF
--- a/docs/findings/tome-module-paths-and-subdirectories.md
+++ b/docs/findings/tome-module-paths-and-subdirectories.md
@@ -1,6 +1,7 @@
 # How `invoke tome·…` finds a module file
 
-**Recorded:** 2026-09-10, closing #109.
+**Recorded:** 2026-09-10, closing #109; extended the same day for the
+`scroll` half.
 
 A tome used to have to be one flat directory. `invoke tome·tui·grid·{Region}`
 took the module name from the **second** segment alone, looked for `tui.sg`,
@@ -41,6 +42,35 @@ every existing tome uses.
 
 `scroll foo;` goes through the same resolver, so a module may be a file or a
 directory with a `mod.sg` in it.
+
+## `scroll` is relative; `tome·` is not
+
+The two roots differ, and that is the whole reason they are tracked separately:
+
+| | rooted at |
+|---|---|
+| `scroll grid;` | the **declaring file's own directory**, then the tome root |
+| `invoke tome·…` / `crate·` / `above·` | the tome root, wherever it is written |
+
+`scroll grid;` inside `tui/vterm.sg` names `tui/grid.sg`, the way `mod grid;`
+in `tui/vterm.rs` names `tui/grid.rs`. Resolving it against the tome root
+wherever it appeared meant a module in a subdirectory could not name the module
+beside it, and the failure — `undefined variable` — said nothing about why.
+
+The root stays in the search list *after* the declaring file's directory, so a
+nested module may still name one of the tome's top-level modules
+(`scroll constants;` from `tui/grid.sg` reaches `constants.sg`), and every flat
+tome is unaffected. When both exist, the sibling wins: searching the root first
+would stop a subdirectory from having a module of its own whenever the tome
+already had one by that name, which is exactly when grouping is wanted.
+
+`current_module_dir` carries the declaring file's directory and is saved and
+restored around each module load, alongside `current_module`.
+
+`above·` is *not* currently relative — it resolves from the tome root like
+`tome·`. That happens to give the right answer for a top-level module and is
+left alone deliberately; making it mean "the parent module" is a semantic
+change, not a fix.
 
 ## What is still flat
 

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -1288,6 +1288,15 @@ pub struct Interpreter {
     pub generic_type_bindings: HashMap<String, String>,
     /// Current source directory for resolving relative module paths
     pub current_source_dir: Option<String>,
+    /// The directory of the module file currently being executed, when that is
+    /// not the tome root.
+    ///
+    /// `scroll foo;` is *relative*: inside `tui/vterm.sg` it names
+    /// `tui/grid.sg`, the way `mod grid;` in `tui/vterm.rs` names
+    /// `tui/grid.rs`. `tome·` is not -- it is rooted at the tome wherever it
+    /// is written -- so the two directories are tracked separately rather than
+    /// by moving `current_source_dir` around.
+    pub current_module_dir: Option<String>,
     /// Loaded crates registry (crate_name -> true if loaded)
     pub loaded_crates: HashSet<String>,
     /// Crates currently being loaded (for circular dependency detection)
@@ -1425,6 +1434,7 @@ impl Interpreter {
             current_self_type: None,
             generic_type_bindings: HashMap::new(),
             current_source_dir: None,
+            current_module_dir: None,
             loaded_crates: HashSet::new(),
             loading_crates: HashSet::new(),
             project_root: None,
@@ -3833,15 +3843,33 @@ impl Interpreter {
                     // External module: `scroll foo;` - foo.sigil, foo.sg, or a
                     // directory of its own carrying foo/mod.sg, the way the
                     // workspace loader already reads a subdirectory.
-                    if let Some(ref source_dir) = self.current_source_dir {
-                        let module_path = Self::resolve_tome_module(
-                            source_dir,
-                            std::slice::from_ref(&module_name),
-                        )
-                        .map(|(_, file)| std::path::PathBuf::from(file))
-                        .unwrap_or_else(|| {
-                            std::path::Path::new(source_dir).join(format!("{}.sg", module_name))
-                        });
+                    // Searched from the declaring file's own directory first,
+                    // then the tome root. A `scroll` is relative, so
+                    // `scroll grid;` inside `tui/vterm.sg` names `tui/grid.sg`
+                    // and not a `grid.sg` at the root that may not exist. The
+                    // root stays in the list because every flat tome relies on
+                    // it, and because a nested module may still name one of the
+                    // tome's top-level modules.
+                    let search_dirs: Vec<String> = self
+                        .current_module_dir
+                        .iter()
+                        .chain(self.current_source_dir.iter())
+                        .cloned()
+                        .collect();
+                    if !search_dirs.is_empty() {
+                        let module_path = search_dirs
+                            .iter()
+                            .find_map(|dir| {
+                                Self::resolve_tome_module(
+                                    dir,
+                                    std::slice::from_ref(&module_name),
+                                )
+                            })
+                            .map(|(_, file)| std::path::PathBuf::from(file))
+                            .unwrap_or_else(|| {
+                                std::path::Path::new(&search_dirs[0])
+                                    .join(format!("{}.sg", module_name))
+                            });
 
                         if module_path.exists() {
                             crate::sigil_debug!(
@@ -3857,9 +3885,16 @@ impl Interpreter {
                                         Ok(parsed_file) => {
                                             // Save current module context
                                             let prev_module = self.current_module.clone();
+                                            let prev_module_dir =
+                                                self.current_module_dir.clone();
 
                                             // Set module context for registering definitions
                                             self.current_module = Some(module_name.clone());
+                                            // A `scroll` inside this file is
+                                            // relative to *this* file.
+                                            self.current_module_dir = module_path
+                                                .parent()
+                                                .map(|p| p.to_string_lossy().into_owned());
 
                                             // Execute module definitions
                                             for item in &parsed_file.items {
@@ -3874,6 +3909,7 @@ impl Interpreter {
 
                                             // Restore previous module context
                                             self.current_module = prev_module;
+                                            self.current_module_dir = prev_module_dir;
                                         }
                                         Err(e) => {
                                             crate::sigil_warn!(
@@ -3894,9 +3930,9 @@ impl Interpreter {
                             }
                         } else {
                             crate::sigil_debug!(
-                                "DEBUG Module file not found: {} (source_dir={})",
+                                "DEBUG Module file not found: {} (searched {})",
                                 module_path.display(),
-                                source_dir
+                                search_dirs.join(", ")
                             );
                         }
                     } else {
@@ -4167,10 +4203,16 @@ impl Interpreter {
                                     if let Ok(source) = std::fs::read_to_string(&module_file) {
                                         // Save current module context
                                         let prev_module = self.current_module.clone();
+                                        let prev_module_dir = self.current_module_dir.clone();
 
                                         // Set module context for the tome module
                                         // This ensures impl methods are registered correctly
                                         self.current_module = Some(module_name.clone());
+                                        // A `scroll` inside this file is
+                                        // relative to *this* file.
+                                        self.current_module_dir = std::path::Path::new(&module_file)
+                                            .parent()
+                                            .map(|p| p.to_string_lossy().into_owned());
 
                                         let mut parser = crate::Parser::new(&source);
                                         if let Ok(parsed_file) = parser.parse_file() {
@@ -4181,6 +4223,7 @@ impl Interpreter {
 
                                         // Restore previous module context
                                         self.current_module = prev_module;
+                                        self.current_module_dir = prev_module_dir;
                                     }
                                 }
                             }
@@ -27076,6 +27119,51 @@ mod tests {
                 ⤺ a[0];
             }";
         assert!(matches!(run(source), Ok(Value::Int(42))));
+    }
+
+    #[test]
+    fn a_scroll_inside_a_nested_module_names_its_sibling() {
+        // `scroll` is relative, the way `mod grid;` in `tui/vterm.rs` names
+        // `tui/grid.rs`. It was resolved against the tome root wherever it was
+        // written, so a module in a subdirectory could not name the module
+        // beside it -- and `undefined variable` says nothing about why.
+        let tome = TempTome::new("relscroll");
+        tome.write("tui/vterm.sg", "☉ rite vterm_id() -> i32 { 7 }")
+            .write("tui/mod.sg", "☉ scroll vterm;\n☉ rite layer() -> i32 { 1 }");
+        let source = "\
+            invoke tome·tui·{layer};
+            rite main() { ⤺ layer() + vterm_id(); }";
+        assert!(matches!(tome.run(source), Ok(Value::Int(8))));
+    }
+
+    #[test]
+    fn a_nested_scroll_still_falls_back_to_the_tome_root() {
+        // The declaring file's directory is searched first, not instead: a
+        // module in a subdirectory may still name one of the tome's top-level
+        // modules, and every flat tome depends on the root being reached.
+        let tome = TempTome::new("relfallback");
+        tome.write("constants.sg", "☉ rite esc() -> i32 { 27 }")
+            .write("tui/grid.sg", "☉ scroll constants;\n☉ rite g() -> i32 { esc() }");
+        let source = "\
+            invoke tome·tui·grid·{g};
+            rite main() { ⤺ g(); }";
+        assert!(matches!(tome.run(source), Ok(Value::Int(27))));
+    }
+
+    #[test]
+    fn the_sibling_wins_over_a_root_module_of_the_same_name() {
+        // Both exist, and the one beside the declaring file is the one it
+        // means. Searching the root first would have made a subdirectory
+        // unable to have a module of its own whenever the tome already had one
+        // by that name -- which is exactly when grouping is wanted.
+        let tome = TempTome::new("relshadow");
+        tome.write("grid.sg", "☉ rite which() -> i32 { 1 }")
+            .write("tui/grid.sg", "☉ rite which() -> i32 { 2 }")
+            .write("tui/mod.sg", "☉ scroll grid;\n☉ rite pick() -> i32 { which() }");
+        let source = "\
+            invoke tome·tui·{pick};
+            rite main() { ⤺ pick(); }";
+        assert!(matches!(tome.run(source), Ok(Value::Int(2))));
     }
 
     #[test]


### PR DESCRIPTION
Closes #138 (does not auto-close — this targets `develop`).

Follow-on from #128. Found by walking a morgoth-shaped tree against `develop`
rather than waiting for the report — morgoth has just gained subdirectories,
and `scroll` is the spelling its `lib.sg` already uses for all 18 of its
modules, so it is the one that gets reached for when five of them move into
`src/tui/`.

## The gap

`scroll` was resolved against the **tome root** wherever it was written, so a
module in a subdirectory could not name the module beside it:

```
probe/
├── main.sg
└── tui/
    ├── mod.sg     ☉ scroll vterm;
    └── vterm.sg   ☉ rite vterm_id() -> i32 { 7 }
```

```console
$ sigil run ./main.sg
1
Runtime error in './main.sg': [R0003] Runtime error: undefined variable: `vterm_id`
```

`tui/mod.sg` loaded — `layer()` resolves — but its `scroll vterm;` searched
`<root>/vterm.sg`. Same for a sibling naming a sibling: `scroll grid;` inside
`tui/vterm.sg` did not find `tui/grid.sg`.

## Two roots, not one

| | rooted at |
|---|---|
| `scroll grid;` | the **declaring file's own directory**, then the tome root |
| `invoke tome·…` / `crate·` / `above·` | the tome root, wherever it is written |

`scroll grid;` in `tui/vterm.sg` names `tui/grid.sg`, the way `mod grid;` in
`tui/vterm.rs` names `tui/grid.rs`. `tome·` is rooted at the tome *by
definition*. Both read `current_source_dir`, which is why they cannot share it
— moving that field around per module would have broken `tome·` from inside a
nested module.

`current_module_dir` carries the declaring file's directory, saved and restored
around each module load alongside `current_module`, at both loaders.

The root stays in the search list **after** the declaring file's directory, so:

- a nested module may still name a top-level one (`scroll constants;` from
  `tui/grid.sg` reaches `constants.sg`) — test included;
- every flat tome is untouched — 798-test suite unchanged;
- when both exist, **the sibling wins** — test included. Searching the root
  first would stop a subdirectory from having a module of its own whenever the
  tome already had one by that name, which is exactly when grouping is wanted.

## The boundary, measured

Checked against `develop` before the change, so the report says what was
actually broken rather than what looked broken:

| | before | after |
|---|---|---|
| `invoke tome·tui·grid·{Region}` from anywhere | ✅ | ✅ |
| `invoke tome·tui·{layer_name}` → `tui/mod.sg` | ✅ | ✅ |
| `invoke tome·constants·{esc}` from inside `tui/grid.sg` | ✅ | ✅ |
| `invoke tome·tui·widgets·button·{…}` (two levels) | ✅ | ✅ |
| `scroll tui;` at the tome root → `tui/mod.sg` | ✅ | ✅ |
| `scroll vterm;` inside `tui/mod.sg` | ❌ | ✅ |
| `scroll grid;` inside `tui/vterm.sg` | ❌ | ✅ |

A full morgoth-shaped tree — `constants.sg`, `render.sg`, `main.sg`, and
`tui/{mod,grid,vterm,layout}.sg` plus `tui/widgets/button.sg`, with a `Region`
built in one subdirectory module, passed through a second, and read in a
third — was already correct and is unchanged.

## `above·`

`above·constants·{esc}` from `tui/grid.sg` works today, but only because
`above` resolves from the tome root like `tome·` and `constants` happens to be
at the root. Whether `above` should mean "the parent module" is a semantic
question, not a bug — left alone deliberately, and called out in the findings
note so it is not mistaken for an oversight.

## Tests

Baseline measured on `develop` (22a43b4) first, same machine, same flags:

Rebased onto `develop` @ `1bdabfc` (was 9 behind; no conflict). Re-measured on
both sides after the rebase:

| | develop @ 1bdabfc | this branch |
|---|---|---|
| `RUST_MIN_STACK=33554432 cargo test --release --no-fail-fast` (lib) | 581 passed / 2 failed | **584 passed / 2 failed** |
| bin | 46 passed / 0 failed | 46 passed / 0 failed |
| `jormungandr/tests/run_tests_rust.sh` | 800 / 4 failed / 2 skipped | 800 / 4 failed / 2 skipped |

The 2 unit failures are the pre-existing
`llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}`; the 4 suite
failures are the Kafka/AMQP broker tests. Identical on both sides.

`docs/findings/tome-module-paths-and-subdirectories.md` gains the `scroll`
half — the two roots, the search order, why the sibling wins, and the `above·`
note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcjF6FPweMf1gk7DYXLkWC