### PR TITLE
fix(interpreter): write an array slot through the array, not a copy of it

### DIFF
--- a/docs/findings/arrays-are-reference-like.md
+++ b/docs/findings/arrays-are-reference-like.md
@@ -1,0 +1,100 @@
+# Sigil arrays are reference-like, and one write pretended otherwise
+
+**Recorded:** 2026-09-10, closing #115.
+
+`arr[i] = v` inside a function was **silently discarded** when the function
+returned. The callee saw its own write; the caller did not.
+
+## The table
+
+| mutation inside a function | propagated before #115 |
+|---|---|
+| `arr[0] = 42` | **no** |
+| `arr[0].field = 42` | yes |
+| `arr[0][0] = 42` | yes |
+| `push(arr, v)` | yes |
+| `s.items[0] = 42` (array through a struct field) | yes |
+
+One row of five. That is what made it dangerous: three neighbouring mutations
+work, so nobody suspects the fourth, and there is no error to suspect it *by*.
+
+## What it cost
+
+It shaped a codebase before anyone identified it. morgoth carried the comment
+
+```sigil
+// Swap focused pane with previous; inline — array slot swap only
+// works in same scope as the panes declaration (Phase 26)
+```
+
+Pane swapping stayed inline in a ~1000-line `main()` because extracting it into
+a `rite` silently stopped working. A compiler bug produced a monofile, and the
+diagnosis stopped at the symptom.
+
+## The cause
+
+`eval_assign`'s `Expr::Index` arm had a special case for a **single-segment
+path** base — `arr[i] = v`, and nothing else:
+
+```rust
+if let Value::Array(arr) = current {
+    let borrowed = arr.borrow();
+    let mut new_arr = borrowed.clone();          // clone the whole vector
+    drop(borrowed);
+    if idx < new_arr.len() {
+        new_arr[idx] = val.clone();
+        self.environment
+            .borrow_mut()
+            .set(name, Value::Array(Rc::new(RefCell::new(new_arr))))?;  // rebind to a NEW Rc
+        return Ok(val);
+    }
+}
+```
+
+It cloned the vector, wrote the element, and repointed the *local binding* at a
+new `Rc`. The callee then read its own write through the repointed name; the
+caller still held the original array.
+
+Every other row falls through to the generic path below it, which does
+`arr.borrow_mut(); borrowed[idx] = val;` — a write through the shared `Rc`.
+`s.items[0]` and `arr[0][0]` never took the special case because their base is
+a field or an index, not a single-segment path. That asymmetry is what located
+the bug: both spellings end at "set element 0 of an array", so the difference
+had to be in how the base was reached.
+
+The fix is to write through the `Rc` the binding already holds.
+
+## Why this is not a semantics change
+
+Sigil arrays were **already** reference-like, and provably so before the fix:
+
+```sigil
+≔ mut a = [1];  ≔ mut b = a;
+push(b, 99);      // len(a) == 2   -- already aliased
+b[0].field = 42;  // a[0].field    -- already aliased
+b[0][0] = 42;     // a[0][0]       -- already aliased
+b[0] = 42;        // a[0] == 1     -- the odd one out
+```
+
+The broken path was not value semantics either. A copy would have given the
+caller an independent array; this rebound one binding and left every *other*
+alias pointing at the original. It was neither aliasing nor copying — it was a
+lost write.
+
+**One visible consequence:** the last line above now leaves `a[0] == 42`. That
+is the outlier joining the other three, not aliasing being introduced. It is
+pinned by `an_array_binding_aliases_rather_than_copies` so a reversal fails
+loudly.
+
+## If you want value semantics instead
+
+That is a language decision, not this fix. It would mean changing `push`,
+`arr[i].f = v`, `arr[i][j] = v` and array-through-a-struct-field as well, and
+deciding what `≔ b = a` means. Silently dropping one write is the only outcome
+that cannot be right, which is what #115 says.
+
+## Scope
+
+Interpreter only. The Cranelift JIT rejects a program with an untyped array
+parameter outright (`Undefined variable: arr`), before and after, so it never
+reached this shape.

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -5110,7 +5110,18 @@ impl Interpreter {
                     _ => return Err(RuntimeError::new(format!("Index must be an integer, got {:?}", idx_val))),
                 };
 
-                // Get the array and modify it
+                // Get the array and modify it.
+                //
+                // In place, through the `Rc` the binding already holds. This
+                // used to clone the whole vector, set the element, and rebind
+                // the name to a *new* `Rc`, which made `arr[i] = v` the one
+                // mutation that did not survive a return: the callee saw its
+                // own write because its local binding had been repointed, and
+                // the caller kept the original array. `arr[i].f = v`,
+                // `arr[i][j] = v`, `push(arr, v)` and `s.items[i] = v` all
+                // mutate through the shared `Rc` and always propagated, so
+                // three mutations out of four worked and nobody suspected the
+                // fourth.
                 if let Expr::Path(path) = expr.as_ref() {
                     if path.segments.len() == 1 {
                         let name = &path.segments[0].ident.name;
@@ -5119,14 +5130,9 @@ impl Interpreter {
                         })?;
 
                         if let Value::Array(arr) = current {
-                            let borrowed = arr.borrow();
-                            let mut new_arr = borrowed.clone();
-                            drop(borrowed);
-                            if idx < new_arr.len() {
-                                new_arr[idx] = val.clone();
-                                self.environment
-                                    .borrow_mut()
-                                    .set(name, Value::Array(Rc::new(RefCell::new(new_arr))))?;
+                            let mut borrowed = arr.borrow_mut();
+                            if idx < borrowed.len() {
+                                borrowed[idx] = val.clone();
                                 return Ok(val);
                             }
                         }
@@ -26974,6 +26980,102 @@ mod tests {
             invoke tome·output·{width};
             rite main() { ⤺ width(); }";
         assert!(matches!(tome.run(source), Ok(Value::Int(3))));
+    }
+
+    /// Every way a function can mutate an array its caller passed it.
+    ///
+    /// | mutation inside a function | propagated before #115 |
+    /// |---|---|
+    /// | `arr[0] = 42`      | **no** |
+    /// | `arr[0].field = 42`| yes |
+    /// | `arr[0][0] = 42`   | yes |
+    /// | `push(arr, v)`     | yes |
+    /// | `s.items[0] = 42`  | yes |
+    ///
+    /// One row of five behaved differently from the rest, and silently: the
+    /// callee saw its own write, so the function looked right in isolation and
+    /// under any test that checked state from inside it. Only the caller saw
+    /// the loss. Three of four neighbouring mutations working is what made it
+    /// lethal -- it shaped morgoth, whose pane swap had to stay inline in a
+    /// ~1000-line `main()` because extracting it stopped working.
+    ///
+    /// One test per row, so the next person reading this can see at a glance
+    /// which propagate.
+    #[test]
+    fn an_array_slot_assigned_in_a_function_reaches_the_caller() {
+        // The row that was broken. `arr[i] = v` on a bare name cloned the
+        // whole vector, set the element, and rebound the *local* name to a new
+        // `Rc` -- so the write landed on an array nobody else held.
+        let source = "\
+            rite set(arr) { arr[0] = 42; }
+            rite main() { ≔ mut a = [1, 2]; set(a); ⤺ a[0]; }";
+        assert!(matches!(run(source), Ok(Value::Int(42))));
+    }
+
+    #[test]
+    fn an_element_field_assigned_in_a_function_reaches_the_caller() {
+        let source = "\
+            ☉ Σ H { ☉ n: i64 }
+            rite set(arr) { arr[0].n = 42; }
+            rite main() { ≔ mut a = [H { n: 1 }]; set(a); ⤺ a[0].n; }";
+        assert!(matches!(run(source), Ok(Value::Int(42))));
+    }
+
+    #[test]
+    fn a_nested_array_slot_assigned_in_a_function_reaches_the_caller() {
+        // `arr[0][0] = v` working while `arr[0] = v` did not is what showed
+        // the difference was an implementation artifact and not value
+        // semantics: the base of the outer index is itself an index, so it
+        // never took the bare-name path.
+        let source = "\
+            rite set(o) { o[0][0] = 42; }
+            rite main() { ≔ mut a = [[1, 2]]; set(a); ⤺ a[0][0]; }";
+        assert!(matches!(run(source), Ok(Value::Int(42))));
+    }
+
+    #[test]
+    fn a_push_in_a_function_reaches_the_caller() {
+        let source = "\
+            rite add(arr) { push(arr, 99); }
+            rite main() { ≔ mut a = [1]; add(a); ⤺ len(a); }";
+        assert!(matches!(run(source), Ok(Value::Int(2))));
+    }
+
+    #[test]
+    fn an_array_reached_through_a_struct_field_reaches_the_caller() {
+        // The asymmetry that located the bug. `s.items[0] = v` and
+        // `arr[0] = v` both end at "set element 0 of an array", and only the
+        // second was lost -- so the difference had to be in how the base was
+        // reached, not in what was done to it. A struct field is not a
+        // single-segment path, so it fell through to the shared-`Rc` write
+        // that every other row already used.
+        let source = "\
+            ☉ Σ S { ☉ items: [i64] }
+            rite set(s) { s.items[0] = 42; }
+            rite main() { ≔ mut s = S { items: [1, 2] }; set(s); ⤺ s.items[0]; }";
+        assert!(matches!(run(source), Ok(Value::Int(42))));
+    }
+
+    #[test]
+    fn an_array_binding_aliases_rather_than_copies() {
+        // What the rows above are consistent *with*. Sigil arrays are
+        // reference-like: `≔ b = a` shares the array, and a push, an element
+        // field write and a nested slot write through `b` were all already
+        // visible through `a` before #115. Only the bare-name slot assignment
+        // was not -- and it was not a copy either, since it rebound one
+        // binding and left every other alias pointing at the original.
+        //
+        // Pinned because the fix makes this row agree with the other three,
+        // which is a visible change in same-scope behaviour and should fail
+        // loudly if anyone reverses it.
+        let source = "\
+            rite main() {
+                ≔ mut a = [1, 2];
+                ≔ mut b = a;
+                b[0] = 42;
+                ⤺ a[0];
+            }";
+        assert!(matches!(run(source), Ok(Value::Int(42))));
     }
 
     #[test]


### PR DESCRIPTION
Closes #115 (does not auto-close — this targets `develop`).

> ### ⚠️ One visible behaviour change, called out before you merge
>
> `≔ mut b = a; b[0] = 42;` now leaves `a[0] == 42`. That is the outlier
> joining the other three mutations, **not** aliasing being introduced —
> `push`, `b[0].field = v` and `b[0][0] = v` through the same alias were
> *already* visible through `a` before this change. Evidence below. It is
> pinned by its own test so a reversal fails loudly.
>
> I judged this a one-path fix rather than a semantics decision, for the
> reasons in "Why this is not a semantics change". If you read it the other
> way, this should not land without Daemon.

## Cause

`eval_assign`'s `Expr::Index` arm carried a special case for a **single-segment
path** base — `arr[i] = v`, and nothing else:

```rust
if let Value::Array(arr) = current {
    let borrowed = arr.borrow();
    let mut new_arr = borrowed.clone();          // clone the whole vector
    drop(borrowed);
    if idx < new_arr.len() {
        new_arr[idx] = val.clone();
        self.environment
            .borrow_mut()
            .set(name, Value::Array(Rc::new(RefCell::new(new_arr))))?;  // rebind to a NEW Rc
        return Ok(val);
    }
}
```

It cloned the vector, wrote the element, and repointed the *local binding* at a
new `Rc`. The callee read its own write through the repointed name; the caller
still held the original array. Hence "visible inside, gone outside", with no
error anywhere.

Everything else falls through to the generic path immediately below, which does
`arr.borrow_mut(); borrowed[idx] = val;` — a write through the shared `Rc`.

**The struct-field asymmetry in morgoth #3 is what located it.** `s.items[0] = v`
and `arr[0] = v` both end at "set element 0 of an array", and only the second
was lost — so the difference had to be in how the *base* was reached, not in
what was done to it. A field access is not a single-segment path, so it never
took the special case. Same for `arr[0][0] = v`, whose base is an index.

The fix writes through the `Rc` the binding already holds.

## The table, as tests

One test per row, so the next person can see at a glance which propagate:

| mutation inside a function | before | after | test |
|---|---|---|---|
| `arr[0] = 42` | ❌ | ✅ | `an_array_slot_assigned_in_a_function_reaches_the_caller` |
| `arr[0].field = 42` | ✅ | ✅ | `an_element_field_assigned_in_a_function_reaches_the_caller` |
| `arr[0][0] = 42` | ✅ | ✅ | `a_nested_array_slot_assigned_in_a_function_reaches_the_caller` |
| `push(arr, v)` | ✅ | ✅ | `a_push_in_a_function_reaches_the_caller` |
| `s.items[0] = 42` | ✅ | ✅ | `an_array_reached_through_a_struct_field_reaches_the_caller` |
| `≔ b = a; b[0] = 42` (same scope) | ❌ | ✅ | `an_array_binding_aliases_rather_than_copies` |

Run against `develop` @ `22a43b4` unchanged, **exactly two fail** — the
bare-name slot assignment and the aliasing row. The other four pass on both
sides; they are there to document what already worked, which is the half of the
table that made this bug invisible.

## Why this is not a semantics change

Sigil arrays were already reference-like, and provably so *before* the fix:

```sigil
≔ mut a = [1];  ≔ mut b = a;
push(b, 99);      // len(a) == 2   -- already aliased
b[0].field = 42;  // a[0].field    -- already aliased
b[0][0] = 42;     // a[0][0]       -- already aliased
b[0] = 42;        // a[0] == 1     -- the odd one out
```

The broken path was not value semantics either. A copy would have handed the
caller an independent array; this rebound *one binding* and left every other
alias pointing at the original. It was neither aliasing nor copying — it was a
lost write, which is the one outcome #115 says cannot be right.

Choosing value semantics instead would mean changing `push`, `arr[i].f = v`,
`arr[i][j] = v` and array-through-a-struct-field too, and deciding what
`≔ b = a` means. That would be the language decision; this is not it.

## Verification

Baseline measured on `develop` (22a43b4) first, same machine, same flags:

| | develop | this branch |
|---|---|---|
| `RUST_MIN_STACK=33554432 cargo test --release --no-fail-fast` (lib) | 575 passed / 2 failed | **581 passed / 2 failed** |
| bin | 45 passed / 0 failed | 45 passed / 0 failed |
| `jormungandr/tests/run_tests_rust.sh` | 798 / 4 failed / 2 skipped | 798 / 4 failed / 2 skipped |
| **morgoth `run_tests.sh`** @ `adad4cf` (PR #3) | **239 / 0** | **239 / 0** |

The 2 unit failures are the pre-existing
`llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}`; the 4 suite
failures are the Kafka/AMQP broker tests.

morgoth is the strongest evidence available: 239 tests over the codebase this
bug actually shaped, run with both binaries via `SIGIL_COMPILER`, in a
throwaway worktree at `adad4cf` — the decompose session's own worktree was not
touched. Nothing anywhere depended on the copy.

## Scope

Interpreter only. The Cranelift JIT rejects a program with an untyped array
parameter outright (`Undefined variable: arr`) both before and after, so it
never reached this shape — a separate pre-existing limitation, not touched here.

`docs/findings/arrays-are-reference-like.md` records the table, the cause, the
asymmetry that located it, the one visible consequence, and what choosing value
semantics would actually require.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcjF6FPweMf1gk7DYXLkWC
