### PR TITLE
test(migrate): record the build the sweep measured with, not just its hash

### DIFF
--- a/tools/collision-sweep/README.md
+++ b/tools/collision-sweep/README.md
@@ -41,12 +41,19 @@ Writes into the output directory:
 
 | file | |
 |---|---|
-| `manifest.txt` | root, file count, digest of the sorted relative path list, sha256 of the binary |
+| `manifest.txt` | root, file count, digest of the sorted relative path list, and the build: binary sha256, commit, branch, clean/dirty |
 | `findings.tsv` | `relative/path` ⇥ `name` ⇥ `uses`, sorted |
 | `summary.txt` | the headline counts, and names ranked by files affected |
 | `raw.err` | the `migrate` stderr the report was parsed from |
 
-**The corpus and the build are reported, not assumed.** "The crate registry"
+**The corpus and the build are reported, not assumed.** A shared build output
+is an input nobody declares — a sibling session measured Sigil with a binary
+built from a dirty feature branch 49 commits ahead of `develop` and 173 behind
+it, and the number it produced read as a `develop` number. So the manifest
+records the build's commit, branch and clean/dirty state alongside the hash,
+and both `sweep.sh` and `compare.sh` say so loudly when a tree was dirty: a
+hash tells you two runs used different code, but only a commit plus a clean
+flag tells you *which* code, and whether anyone else can check it out. "The crate registry"
 is not reproducible across machines or months; a file count plus a digest of
 the relative path list is. `sigil` has no `--version`, so the binary is
 recorded by sha256 — a path and a timestamp do not say which code ran, which is

--- a/tools/collision-sweep/compare.sh
+++ b/tools/collision-sweep/compare.sh
@@ -45,6 +45,17 @@ if [ -n "$bb" ] && [ "$bb" = "$ab" ]; then
     echo "compare: note -- both sweeps used the same binary ($bb)" >&2
 fi
 
+# A dirty build cannot be cited. The commit in the manifest does not describe
+# what ran, so a result measured from one is not reproducible by anyone else.
+for side in 1 2; do
+    eval "dir=\$$side"
+    tree=$(awk '/^build-tree:/ {print $2}' "$dir/manifest.txt" 2>/dev/null || true)
+    if [ "$tree" = "DIRTY" ]; then
+        echo "compare: WARNING -- $dir was measured with a binary built from a DIRTY tree;" >&2
+        echo "  its build-commit does not describe what ran, so this side is not citable" >&2
+    fi
+done
+
 added=$(LC_ALL=C comm -13 "$before" "$after" || true)
 removed=$(LC_ALL=C comm -23 "$before" "$after" || true)
 

--- a/tools/collision-sweep/sweep.sh
+++ b/tools/collision-sweep/sweep.sh
@@ -67,14 +67,42 @@ digest=$(sed "s|^$root_abs/||" "$out/files.txt" | LC_ALL=C sha256sum | cut -d' '
 # is the whole question a before/after comparison is asking.
 sigil_digest=$(sha256sum "$sigil" | cut -d' ' -f1)
 
+# ...and by provenance, which is the half a digest cannot supply. A shared
+# build output is an input nobody declares: a sibling session measured Sigil
+# with a binary built from a dirty feature branch 49 commits ahead and 173
+# behind `develop`, and the number it reported read as a `develop` number.
+# A hash says two runs used different code; a commit and a dirty flag say
+# *which* code, and whether it was anything a reader can check out.
+build_dir=$(dirname "$sigil")
+sigil_commit="unknown"
+sigil_branch="unknown"
+sigil_tree="unknown"
+if repo_root=$(git -C "$build_dir" rev-parse --show-toplevel 2>/dev/null); then
+    sigil_commit=$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || echo unknown)
+    sigil_branch=$(git -C "$repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+    if [ -n "$(git -C "$repo_root" status --porcelain 2>/dev/null)" ]; then
+        sigil_tree="DIRTY"
+    else
+        sigil_tree="clean"
+    fi
+fi
+
 {
-    echo "root:         $root_abs"
-    echo "files:        $file_count"
-    echo "path-digest:  $digest"
-    echo "binary:       $sigil"
+    echo "root:          $root_abs"
+    echo "files:         $file_count"
+    echo "path-digest:   $digest"
+    echo "binary:        $sigil"
     echo "binary-sha256: $sigil_digest"
-    echo "swept:        $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "build-commit:  $sigil_commit"
+    echo "build-branch:  $sigil_branch"
+    echo "build-tree:    $sigil_tree"
+    echo "swept:         $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 } > "$out/manifest.txt"
+
+if [ "$sigil_tree" = "DIRTY" ]; then
+    echo "sweep: WARNING -- the binary was built from a DIRTY tree ($sigil_branch @ $sigil_commit)." >&2
+    echo "  The commit above does not describe what ran. Commit or stash before measuring." >&2
+fi
 
 echo "sweep: $file_count files under $root_abs" >&2
 


### PR DESCRIPTION
Follow-on to #133. Prompted by a concrete incident today, not a hypothetical.

## What happened

The shared `sigil-lang` checkout sat on `feature/s1-sigil-web-wasm-compat`
@ `c47dfd2` — **49 commits ahead of `develop`, 173 behind it, with 5 modified
tracked files** — and its `parser/target/release/sigil` was rebuilt in place at
13:44. Sibling sessions measuring Sigil picked up that binary and their numbers
read as `develop` numbers. Nobody was careless; a shared build output is simply
an input that nobody declares.

`sweep.sh` already recorded `binary-sha256`, which distinguishes two builds but
does not say what either one **is**. A hash tells you two runs used different
code. Only a commit plus a clean flag tells you *which* code — and whether
anyone else can check it out and get the same answer.

## The change

`manifest.txt` gains three fields beside the hash:

```
binary-sha256: 1fc3e8c90e84db7e51fd651b8e19c6302d721c66973d0adb1d61481e3779179c
build-commit:  0ca9ab2
build-branch:  fix/sweep-records-its-build
build-tree:    clean
```

and neither script will be quiet about a dirty build:

```console
$ ./sweep.sh corpus -o /tmp/out
sweep: WARNING -- the binary was built from a DIRTY tree (my-branch @ 5c89f3c).
  The commit above does not describe what ran. Commit or stash before measuring.

$ ./compare.sh /tmp/dirty /tmp/clean
compare: WARNING -- /tmp/dirty was measured with a binary built from a DIRTY tree;
  its build-commit does not describe what ran, so this side is not citable
```

Provenance is read from **the binary's own repository**, via
`git -C "$(dirname "$sigil")"`, not the corpus's — so pointing `--sigil` at
another checkout reports *that* checkout, which is exactly the case that went
wrong. A binary outside any git tree reports `unknown` rather than failing: the
sweep still runs, it just cannot be cited.

## Verified both ways

Not asserted — run in both states. With the tree dirty it printed the warning
and `build-tree: DIRTY`; with it clean, `build-commit: 0ca9ab2` and
`build-tree: clean`. The first run caught its *own* uncommitted edits, which is
the behaviour I wanted.

## Tests

Shell-only change; no Rust touched. Measured on `develop` (5c89f3c) anyway,
same machine, same flags:

| | develop | this branch |
|---|---|---|
| `RUST_MIN_STACK=33554432 cargo test --release --no-fail-fast` (lib) | 586 passed / 2 failed | 586 passed / 2 failed |
| bin | 49 passed / 0 failed | 49 passed / 0 failed |

Expected-red on both sides: the 2 lib failures are
`llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}`.

## Context

**This PR is a prompted reaction, not independent convergence.** I wrote it
after a sibling session warned me about the shared build output, and I said at
the time that I would. An earlier draft of this section claimed it as "the
third independent implementation"; that was wrong and is corrected here,
because the distinction changes what the evidence supports.

The honest ledger for today:

| | |
|---|---|
| `sweep.sh`'s original manifest (`binary-sha256`, `path-digest`) — #133 | **independent**, predates all of this |
| morgoth's staleness gate | independent, and it is the thing that *failed* |
| morgoth `a217594` provenance reporting | prompted |
| this PR | prompted |

One independent instance and three prompted reactions. Prompted reactions show
the fix is cheap and wanted; they do not show the need was independently
discovered, and only the second kind supports "missing platform guarantee".

What does hold up: #133's manifest chose `binary-sha256` over path + size +
mtime **before** any of today's near-misses, for the reason that `sigil` has no
`--version` and the path is rebuilt in place — which is exactly what happened
to the shared checkout at 13:44. That is one session solving the problem cold,
and it is the real evidence. `lares#15` tracks the central version and cites it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcjF6FPweMf1gk7DYXLkWC