### PR TITLE
fix(interpreter): refuse an unknown `Type·member` instead of inventing a value

### DIFF
--- a/jormungandr/tests/run_tests_rust.sh
+++ b/jormungandr/tests/run_tests_rust.sh
@@ -100,9 +100,17 @@ run_test() {
     local test_out="$TEMP_DIR/${test_name}.out"
     local test_err="$TEMP_DIR/${test_name}.err"
 
-    # Check if test should be skipped
+    # Check if test should be skipped.
+    #
+    # A `// SKIP` marks a test whose implementation is ABSENT -- the feature
+    # does not exist, so the test cannot pass. It is not a flaky test and not
+    # a disabled one. The marker carries the issue number for the gap, and it
+    # is echoed here so a reader of the run reaches the gap without opening
+    # the file.
     if grep -q "^// SKIP" "$test_file" 2>/dev/null; then
-        echo -e "  ${YELLOW}⏭  SKIP${NC}: $test_name (marked as SKIP)"
+        local skip_reason
+        skip_reason=$(grep -m1 "^// SKIP" "$test_file" | sed 's|^// SKIP *||')
+        echo -e "  ${YELLOW}⏭  SKIP${NC}: $test_name -- ${skip_reason}"
         ((SKIP++))
         return 0
     fi
@@ -250,10 +258,21 @@ if [ $TIMEOUT -gt 0 ]; then
 fi
 echo -e "${BLUE}───────────────────────────────────────────────${NC}"
 
-TOTAL=$((PASS + FAIL))
+# Skips count against the total. Excluding them let "795 passed, 6 skipped"
+# and "795 passed, 0 skipped" print the same 100%, which is the one thing the
+# number must never do -- a skipped test is a feature that does not exist, and
+# hiding it makes the suite report a capability the compiler does not have.
+TOTAL=$((PASS + FAIL + SKIP))
 if [ $TOTAL -gt 0 ]; then
     PERCENTAGE=$((PASS * 100 / TOTAL))
-    echo -e "${BLUE}Pass rate: ${PERCENTAGE}%${NC}"
+    echo -e "${BLUE}Pass rate: ${PERCENTAGE}% (${PASS} of ${TOTAL}; skips count as not passing)${NC}"
+fi
+
+if [ $SKIP -gt 0 ]; then
+    echo
+    echo -e "${YELLOW}${SKIP} test(s) skipped because the implementation is ABSENT, not because${NC}"
+    echo -e "${YELLOW}they are flaky. Each names its issue above. A skip is a missing feature${NC}"
+    echo -e "${YELLOW}that is being counted rather than hidden; it should shrink, not settle.${NC}"
 fi
 
 # Exit with error if any tests failed

--- a/jormungandr/tests/spec/04_memory/P1_005_weak_ref.sg
+++ b/jormungandr/tests/spec/04_memory/P1_005_weak_ref.sg
@@ -1,3 +1,14 @@
+// SKIP #155 -- Rc·downgrade / Weak<T> is UNIMPLEMENTED (04-MEMORY.md § 4.4).
+//
+// The implementation is ABSENT, not flaky. This test does not intermittently
+// fail; it cannot pass until #155 lands.
+//
+// It passed until #146 only because the fallback fabricated a value for the
+// unimplemented `Rc·downgrade`, whose result this test never reads -- the
+// expected `100\n100` comes from `rc` and `rc2` on unrelated lines. It
+// asserted nothing about weak references.
+//
+// Kept rather than deleted so the gap keeps a number a reader can find.
 // Test: Weak references with Rc
 // Spec: 04-MEMORY.md § 4.4 Weak
 // Priority: P1 - Production Ready

--- a/jormungandr/tests/spec/15_protocols/P0_008_reported_evidence.sg
+++ b/jormungandr/tests/spec/15_protocols/P0_008_reported_evidence.sg
@@ -1,3 +1,14 @@
+// SKIP #157 -- `protocol·http·Client` has no constructor; `Client·new` is
+// not registered under any spelling.
+//
+// The implementation is ABSENT, not flaky.
+//
+// It passed until #146 only because the fallback fabricated a `Client { }`.
+// The expected output is the literal `1`, printed after the pipeline, so the
+// test never observed the evidentiality it is named for -- a P0 test that has
+// not exercised its subject.
+//
+// Kept rather than deleted so the gap keeps a number a reader can find.
 // Test: Protocol data is always reported (~)
 // Spec: 15-PROTOCOLS.md § 1 Philosophy
 // Priority: P0 - Bootstrap Critical

--- a/jormungandr/tests/stdlib/test_stdlib_Hologram.sg
+++ b/jormungandr/tests/stdlib/test_stdlib_Hologram.sg
@@ -1,3 +1,13 @@
+// SKIP #158 -- the reachable `Hologram·encode` is a 1-arg stub that shadows
+// the real 4-arg Reed-Solomon encoder; `Hologram·new` does not exist.
+//
+// The implementation is SHADOWED, not flaky.
+//
+// `Hologram·new` was fabricated by the fallback removed in #146, and the
+// `type_of` assertion on `encode` is satisfied equally by the stub and by a
+// real encoder, so this file could not tell them apart.
+//
+// Kept rather than deleted so the gap keeps a number a reader can find.
 // Stdlib Tests: Hologram
 // Hologram type with REAL assertions
 

--- a/jormungandr/tests/stdlib/test_stdlib_MerkleTree.sg
+++ b/jormungandr/tests/stdlib/test_stdlib_MerkleTree.sg
@@ -1,16 +1,38 @@
 // Stdlib Tests: MerkleTree
-// Merkle tree data structure with REAL assertions
+//
+// Constructed through `MerkleTree·from`, which is the constructor that exists.
+// This file previously called `MerkleTree·new`, which does not, and asserted
+// `type_of(mt) == "struct:MerkleTree"` -- an assertion that could not fail,
+// because the fallback removed in #146 named the struct it fabricated after
+// the type in the call.
+//
+// The properties below are the ones that make a Merkle tree a Merkle tree:
+// the root is determined by the contents, and it distinguishes them.
 
 rite main() {
     println("=== Testing MerkleTree ===");
 
-    // MerkleTree·new - creates empty merkle tree
-    ≔ mt = MerkleTree·new();
-    assert_eq(type_of(mt), "struct:MerkleTree");
+    ≔ a = MerkleTree·from(["a", "b"]);
+    ≔ b = MerkleTree·from(["a", "b"]);
+    ≔ c = MerkleTree·from(["a", "c"]);
 
-    // MerkleTree·from - creates tree from data
-    ≔ mtf = MerkleTree·from(["a", "b", "c", "d"]);
-    assert_eq(type_of(mtf), "struct:MerkleTree");
+    // Deterministic: the same leaves give the same root. A root derived from
+    // anything but the contents -- a counter, an address, a random value --
+    // fails here.
+    assert_eq(a.root, b.root);
+
+    // Binding: different leaves give a different root. A constant root, or one
+    // that ignores its input, passes the line above and fails this one. The
+    // two together are what a stub cannot satisfy.
+    assert(a.root != c.root);
+
+    // A root is a SHA-256 hex digest, so 64 characters, and not empty.
+    assert_eq(len(a.root), 64);
+
+    // One leaf hash per element, and a changed element changes its own leaf.
+    assert_eq(len(a.__leaf_hashes__), 2);
+    assert_eq(a.__leaf_hashes__[0], c.__leaf_hashes__[0]);
+    assert(a.__leaf_hashes__[1] != c.__leaf_hashes__[1]);
 
     println("ALL MERKLETREE TESTS PASSED!");
 }

--- a/jormungandr/tests/stdlib/test_stdlib_QHCompressed.sg
+++ b/jormungandr/tests/stdlib/test_stdlib_QHCompressed.sg
@@ -1,3 +1,14 @@
+// SKIP #156 -- QHCompressed has NO registered members; the type is
+// unreachable from Sigil.
+//
+// The implementation is ABSENT, not flaky.
+//
+// It passed until #146 only because the fallback named the struct it
+// fabricated after the type in the call, so `type_of(qhc)` returned
+// "struct:QHCompressed" no matter what. `Wibble·new()` satisfies the same
+// assertion.
+//
+// Kept rather than deleted so the gap keeps a number a reader can find.
 // Stdlib Tests: QHCompressed
 // Compressed quantum hypergraph with REAL assertions
 // TODO: Expand coverage - currently only tests constructor, needs quantum operation testing

--- a/jormungandr/tests/stdlib/test_stdlib_Superposition.sg
+++ b/jormungandr/tests/stdlib/test_stdlib_Superposition.sg
@@ -1,13 +1,43 @@
 // Stdlib Tests: Superposition
-// Superposition type with REAL assertions
-// TODO: Expand coverage - currently only tests constructor, needs collapse/observe testing
+//
+// Constructed through `Superposition·uniform`, which is the constructor that
+// exists. This file previously called `Superposition·new`, which does not,
+// and asserted `type_of(sp) == "struct:Superposition"` -- an assertion that
+// could not fail, because the fallback removed in #146 named the struct it
+// fabricated after the type in the call. `Wibble·new()` satisfied the same
+// shape of assertion.
+//
+// Every assertion below is one a stub would fail.
 
 rite main() {
     println("=== Testing Superposition ===");
 
-    // Superposition·new - creates superposition state
-    ≔ sp = Superposition·new();
-    assert_eq(type_of(sp), "struct:Superposition");
+    ≔ sp = Superposition·uniform([1, 2, 3]);
+
+    // The elements are the ones handed in, not a default.
+    assert_eq(len(sp.__elements__), 3);
+    assert_eq(sp.__elements__[0], 1);
+    assert_eq(sp.__elements__[2], 3);
+
+    // One amplitude per element, and the state is not born collapsed.
+    assert_eq(len(sp.__amplitudes__), 3);
+    assert_eq(sp.__collapsed__, false);
+
+    // Uniform amplitudes are normalised: the squares sum to 1. A constructor
+    // that stored the elements and left amplitudes unset, zeroed, or equal to
+    // 1/n rather than 1/sqrt(n) fails here and passes everything above.
+    ≔ a0 = sp.__amplitudes__[0];
+    ≔ a1 = sp.__amplitudes__[1];
+    ≔ a2 = sp.__amplitudes__[2];
+    ≔ norm = a0 * a0 + a1 * a1 + a2 * a2;
+    assert(norm > 0.999);
+    assert(norm < 1.001);
+
+    // A two-element superposition must not reuse the three-element
+    // amplitudes: 1/sqrt(2) > 1/sqrt(3).
+    ≔ sp2 = Superposition·uniform([7, 8]);
+    assert_eq(len(sp2.__amplitudes__), 2);
+    assert(sp2.__amplitudes__[0] > a0);
 
     println("ALL SUPERPOSITION TESTS PASSED!");
 }

--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -5879,53 +5879,61 @@ impl Interpreter {
                 }
             }
 
-            // Fallback for unknown types from external crates:
+            // `Type·member`, where nothing above has resolved it.
+            //
+            // This used to answer rather than fail. A lowercase `member` was
+            // taken for a constructor on some type from a crate the
+            // interpreter could not load, and returned a marker that
+            // `eval_call` turned into an empty struct named after the type,
+            // discarding the arguments; an uppercase one was taken for a
+            // variant of an enum from the same imagined crate, and fabricated
+            // one. So `Zzz·qqq(1, 2, 3)` evaluated to `Zzz { }` and `Zzz·Qqq`
+            // to a `Qqq` variant, for a `Zzz` that exists nowhere -- and
+            // `check` reported no error either. Anything spelled like a member
+            // got a plausible value instead of an answer, which is why
+            // `File·read_to_string(path)` returned `File { }` for a file that
+            // exists, having read nothing.
+            //
+            // Measured before removing it: across 896 test files, the two arms
+            // fired 12 times in 11 files, and every one was a call to something
+            // that does not exist under any spelling -- `Superposition·new`
+            // where only `·uniform` is registered, `Rc·downgrade` where Weak is
+            // unimplemented. Not one was the external-crate type the leniency
+            // was written for. It furnished defects with values.
             if path.segments.len() == 2 {
                 let type_name = &path.segments[0].ident.name;
-                let method_name = &path.segments[1].ident.name;
+                let member = &path.segments[1].ident.name;
 
-                // Check if this looks like a constructor/method call (lowercase or snake_case)
-                let is_method = method_name
-                    .chars()
-                    .next()
-                    .map_or(false, |c| c.is_lowercase())
-                    || method_name == "new"
-                    || method_name == "default"
-                    || method_name == "from"
-                    || method_name == "try_from"
-                    || method_name == "into"
-                    || method_name == "with_capacity"
-                    || method_name == "from_str";
-
-                if is_method {
-                    // Return a special marker that eval_call will recognize
-                    // Store the type name in a Struct value with a special marker name
-                    return Ok(Value::Struct {
-                        name: format!("__constructor__{}", type_name),
-                        fields: Rc::new(RefCell::new(HashMap::new())),
-                    });
-                } else {
-                    // Looks like an enum variant (PascalCase) - check if it exists
-                    if let Some(TypeDef::Enum(enum_def)) = self.types.get(type_name) {
-                        // Check if variant exists
-                        let variant_exists = enum_def
-                            .variants
-                            .iter()
-                            .any(|v| v.name.name == *method_name);
-                        if !variant_exists {
-                            return Err(RuntimeError::new(format!(
-                                "no variant '{}' on enum '{}'",
-                                method_name, type_name
-                            )));
-                        }
+                // A known enum still answers for its own variants; only the
+                // invented ones are refused.
+                if let Some(TypeDef::Enum(enum_def)) = self.types.get(type_name) {
+                    if enum_def.variants.iter().any(|v| v.name.name == *member) {
+                        return Ok(Value::Variant {
+                            enum_name: type_name.clone(),
+                            variant_name: member.clone(),
+                            fields: None,
+                        });
                     }
-                    // Create unit variant (for external types or verified variants)
-                    return Ok(Value::Variant {
-                        enum_name: type_name.clone(),
-                        variant_name: method_name.clone(),
-                        fields: None,
-                    });
+                    return Err(RuntimeError::new(format!(
+                        "no variant '{}' on enum '{}'",
+                        member, type_name
+                    )));
                 }
+
+                // Name the half that is missing: "no such type" and "no such
+                // member on a type that exists" send the reader to different
+                // places, and the empty struct sent them nowhere.
+                return Err(RuntimeError::new(if self.types.contains_key(type_name.as_str()) {
+                    format!(
+                        "no associated function or variant '{}' on '{}'",
+                        member, type_name
+                    )
+                } else {
+                    format!(
+                        "no such type '{}' (in '{}·{}')",
+                        type_name, type_name, member
+                    )
+                }));
             }
 
             Err(RuntimeError::new(format!(
@@ -27164,6 +27172,66 @@ mod tests {
             invoke tome·tui·{pick};
             rite main() { ⤺ pick(); }";
         assert!(matches!(tome.run(source), Ok(Value::Int(2))));
+    }
+
+    #[test]
+    fn an_unknown_type_is_refused_rather_than_invented() {
+        // #146. `Zzz·qqq(1, 2, 3)` evaluated to `Zzz { }` -- an empty struct
+        // named after a type that exists nowhere, with the arguments
+        // discarded and no error from `check` either. Anything spelled like a
+        // member got a plausible value instead of an answer, which is why
+        // `File·read_to_string(path)` returned `File { }` having read nothing.
+        let err = run("rite main() { ⤺ Zzz·qqq(1, 2, 3); }").unwrap_err();
+        assert!(
+            err.to_string().contains("no such type 'Zzz'"),
+            "expected a no-such-type error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn an_unknown_member_names_the_type_that_does_exist() {
+        // The other half is a different question for the reader: the type is
+        // real and the member is not. The empty struct answered both with the
+        // same silence.
+        let source = "\
+            ☉ Σ P { ☉ x: f32 }
+            rite main() { ⤺ P·nosuchthing(1); }";
+        let err = run(source).unwrap_err();
+        assert!(
+            err.to_string().contains("no associated function or variant 'nosuchthing' on 'P'"),
+            "expected a no-such-member error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn an_uppercase_member_is_refused_the_same_way() {
+        // The capitalised arm fabricated a *variant* rather than a struct, so
+        // fixing only the lowercase one would have left the same defect
+        // reachable by capitalising the name.
+        let err = run("rite main() { ⤺ Zzz·Qqq; }").unwrap_err();
+        assert!(
+            err.to_string().contains("no such type 'Zzz'"),
+            "expected a no-such-type error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn a_real_enum_still_answers_for_its_own_variants() {
+        // The refusal must not reach a variant that exists: enums are still
+        // resolved from their declaration, and only invented ones are refused.
+        let source = "\
+            ☉ ᛈ Status { Success, Failure }
+            rite main() { ≔ s = Status·Success; ⤺ 1; }";
+        assert!(matches!(run(source), Ok(Value::Int(1))));
+
+        let bad = "\
+            ☉ ᛈ Status { Success, Failure }
+            rite main() { ≔ s = Status·Nope; ⤺ 1; }";
+        let err = run(bad).unwrap_err();
+        assert!(
+            err.to_string().contains("no variant 'Nope' on enum 'Status'"),
+            "expected a no-such-variant error, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #146 (does not auto-close — this targets `develop`).

> ### Six suite tests go from passing to skipped. **None of them is a regression.**
> They were passing *because* the language fabricated a value for a call to
> something that does not exist. The fix makes the fabrications visible. The
> total is 807 either way; four tests move from the passed column to the
> skipped one, and each carries a filed issue. Please read the table before
> reverting on the count.

## The defect

`eval_path` carried a fallback "for unknown types from external crates". Any
two-segment path whose second segment was spelled like a member returned a
`__constructor__` marker, which `eval_call` turned into an empty struct named
after the type, discarding the arguments. Any capitalised one returned a
made-up enum variant.

```console
$ sigil check repro.sigil
✓ repro.sigil - no errors
$ sigil run repro.sigil
Zzz·qqq(1, 2, 3) = Zzz {  }
```

So `File·read_to_string(path)` returned `File { }` for a file that exists,
having read nothing, and `Fs·read` returned `Fs { }`. Anything shaped like a
call got a plausible value instead of an answer, with no signal at any stage.

## Measured before removing it

Not assumed — instrumented, run per-file with stderr captured:

| corpus | files | firings |
|---|---:|---:|
| `jormungandr/tests` | 896 | **12**, in 11 files |
| morgoth `src/` + `tests/` | 262 | **0** |

Every one of the 12 was a call to something that does not exist under any
spelling: `Superposition·new` where only `·uniform` is registered,
`Rc·downgrade` where Weak is unimplemented, `Client·new` where nothing is.
**Not one was the external-crate type the leniency was written for.** It
existed to furnish defects with values.

> **An earlier draft of this measurement said zero firings, and that was wrong.**
> The runner redirects each test's stderr to a per-test temp file
> (`$TEMP_DIR/${test_name}.err`), so the instrumentation never appeared in the
> runner's own log — which is what I had grepped. Corrected by running each
> file directly and capturing its stderr.
>
> Worth stating why rather than only that, because the next person will reach
> for the log too: a per-file measurement and a log grep look interchangeable
> until you know where stderr goes, and the log is the obvious artefact to
> grep — it is the thing the run hands you. Reading its silence as evidence of
> absence is the same error as reading `git fsck`'s silence as evidence a
> commit is gone: a check that answers a narrower question than the one asked,
> returning nothing, and nothing being mistaken for an answer.
>
> The corrected number is also the more useful one. Zero firings would have
> suggested the fallback was inert and the fix cosmetic; twelve firings, every
> one masking a missing implementation, is what makes the case.

## What the six tests were doing

Four stdlib files are headed *"…with **REAL assertions**"* and assert only:

```sigil
≔ sp = Superposition·new();
assert_eq(type_of(sp), "struct:Superposition");
```

The fallback named the fabricated struct **after the type in the call**, so
this passes for every possible `X` — demonstrated with a control:

```
Superposition·new()  ->  struct:Superposition
Wibble·new()         ->  struct:Wibble        ← a type invented in that line
```

`P1_005_weak_ref` is the sharpest. It is **P1 — Production Ready** for
04-MEMORY.md § 4.4, and it calls the unimplemented `Rc·downgrade`, **discards
the result**, and passes on `100` / `100` printed by two unrelated lines.
Nothing in it observes a weak reference.

## Disposition

**Skipped — implementation absent, issue filed, test kept not deleted:**

| test | called | reality | issue |
|---|---|---|---|
| `P1_005_weak_ref` | `Rc·downgrade` | Weak unimplemented | #155 |
| `test_stdlib_QHCompressed` | `QHCompressed·new` | no members registered at all | #156 |
| `P0_008_reported_evidence` | `Client·new` | no constructor | #157 |
| `test_stdlib_Hologram` | `Hologram·new` | a 1-arg stub **shadows** the real 4-arg encoder | #158 |

#158 was found along the way and is its own defect: `Hologram·encode` is
registered twice and the later stub wins, so the real Reed-Solomon encoder is
unreachable from Sigil. That is why Hologram is skipped rather than re-pointed
— its reachable constructor is itself a stub, and a test asserting the stub's
behaviour would be the same mistake one level down.

**Re-pointed to the constructor that exists, with assertions that can fail:**

| test | now uses | asserts |
|---|---|---|
| `test_stdlib_Superposition` | `Superposition·uniform` | elements preserved; one amplitude per element; amplitudes **normalised** (squares sum to 1); a 2-element state has larger amplitudes than a 3-element one |
| `test_stdlib_MerkleTree` | `MerkleTree·from` | root is **deterministic** (same leaves → same root) **and binding** (different leaves → different root); root is a 64-char digest; a changed element changes only its own leaf hash |

**Verified by mutation, not by inspection.** I patched a constant Merkle root
and un-normalised amplitudes into the stdlib and re-ran:

```
MUTANT build:
  test_stdlib_Superposition  ->  Assertion failed
  test_stdlib_MerkleTree     ->  Assertion failed
  old-style type_of asserts  ->  PASSED          ← on the same mutant
```

The new assertions catch what the old ones could not. That check exists
because replacements of this kind are themselves easy to write vacuously.

## The suite now reports skips honestly

`TOTAL` was `PASS + FAIL`, so skips vanished from the pass rate and
"797 passed, 6 skipped" printed the same 100% as "797 passed, 0 skipped".
Now:

```
✅ Passed: 797
❌ Failed: 4
⏭  Skipped: 6
Pass rate: 98% (797 of 807; skips count as not passing)

6 test(s) skipped because the implementation is ABSENT, not because
they are flaky. Each names its issue above. A skip is a missing feature
that is being counted rather than hidden; it should shrink, not settle.
```

Each skip line echoes its issue number, so a reader of the run reaches the gap
without opening the file:

```
⏭  SKIP: P1_005_weak_ref -- #155 -- Rc·downgrade / Weak<T> is UNIMPLEMENTED (04-MEMORY.md § 4.4).
```

The wording is deliberate: *absent, not flaky*. Those two get conflated within
a month, and then the skip becomes permanent furniture.

## Tests

Measured on `develop` (2a8f1a9) first, same machine, same flags:

| | develop | this branch |
|---|---|---|
| `RUST_MIN_STACK=33554432 cargo test --release --no-fail-fast` (lib) | 586 passed / 2 failed | **590 passed / 2 failed** |
| bin | 49 passed / 0 failed | 49 passed / 0 failed |
| `jormungandr/tests/run_tests_rust.sh` | 801 / 4 failed / 2 skipped | 797 / 4 failed / **6 skipped** |

Expected-red on both sides: the 2 lib failures are
`llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}`; the 4
suite failures are the Kafka/AMQP broker tests.

Four regression tests added, covering both arms (`Zzz·qqq` and `Zzz·Qqq`), the
known-type-unknown-member case, and that a real enum still answers for its own
variants while a bad variant on it still says so.

## Scope

Interpreter only, one hunk in `eval_path`. #124 (`Sys·socket` simulating) is a
**separate** defect and this does not touch it — proven with one program:
`Sys·socket(2,1,0)` → `21000` (registered, executes, simulates) versus
`Sys·nosuchcall(1)` → `Sys { }` (unregistered, this fallback). Neither fix
closes the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcjF6FPweMf1gk7DYXLkWC