### PR TITLE
fix(interpreter): reach a sibling module from an `invoke` inside a subdirectory

### DIFF
--- a/parser/src/interpreter.rs
+++ b/parser/src/interpreter.rs
@@ -4159,8 +4159,29 @@ impl Interpreter {
                         if !self.types.contains_key(&qualified)
                             && self.globals.borrow().get(&qualified).is_none()
                         {
-                            // Load from current source directory
-                            if let Some(source_dir) = &self.current_source_dir.clone() {
+                            // Searched from the declaring file's own directory
+                            // first, then the tome root -- the same list a
+                            // `scroll` uses (#139). An `invoke` is relative for
+                            // the same reason: `invoke tome·constants·{ESC}`
+                            // inside `tui/terminal.sg` means `tui/constants.sg`.
+                            //
+                            // Only the root was searched before, so a module in
+                            // a subdirectory could not reach its own sibling.
+                            // It failed silently -- the `else` below returns
+                            // Ok(()) -- so nothing bound, `sigil check` passed,
+                            // and the first use site said `undefined variable`.
+                            // Worse, it was invisible whenever the top-level
+                            // program imported the same name, which put it in
+                            // scope for everything: the nested module then
+                            // worked by coincidence, and broke for the next
+                            // consumer that did not import it.
+                            let search_dirs: Vec<String> = self
+                                .current_module_dir
+                                .iter()
+                                .chain(self.current_source_dir.iter())
+                                .cloned()
+                                .collect();
+                            if !search_dirs.is_empty() {
                                 // Which of the path's segments name the module,
                                 // and which name the item inside it, is not
                                 // known from the path alone:
@@ -4178,8 +4199,9 @@ impl Interpreter {
                                 let mut segments: Vec<String> =
                                     prefix.iter().skip(1).cloned().collect();
                                 segments.push(simple_name.clone());
-                                let Some((module_name, module_file)) =
-                                    Self::resolve_tome_module(source_dir, &segments)
+                                let Some((module_name, module_file)) = search_dirs
+                                    .iter()
+                                    .find_map(|dir| Self::resolve_tome_module(dir, &segments))
                                 else {
                                     crate::sigil_debug!(
                                         "DEBUG process_use_tree: no tome module file for {:?}",
@@ -27232,6 +27254,45 @@ mod tests {
             err.to_string().contains("no variant 'Nope' on enum 'Status'"),
             "expected a no-such-variant error, got: {err}"
         );
+    }
+
+    #[test]
+    fn a_nested_module_binds_a_constant_from_its_sibling() {
+        // The consumer deliberately does NOT import MARK. That is the whole
+        // point: when the top-level program imports the same constant, it
+        // lands in scope for everything and the nested module's own binding is
+        // never exercised -- so the broken case passes and the module looks
+        // fine. morgoth shipped src/tui/terminal.sg in exactly that state:
+        // `invoke tome·constants·{ESC}` never bound ESC for terminal.sg, and
+        // terminal_init() worked only because src/render.sg independently
+        // imported the same constants. It failed for the first consumer that
+        // did not.
+        //
+        // Constants are the gap, not modules: every neighbouring test here
+        // covers `☉ rite`, and functions were already reached.
+        let tome = TempTome::new("relconst");
+        tome.write("tui/consts.sg", "≔ MARK = 27;")
+            .write("tui/user.sg", "invoke tome·consts·{MARK};\n☉ rite emit() -> i32 { MARK }");
+        let source = "\
+            invoke tome·tui·user·{emit};
+            rite main() { ⤺ emit(); }";
+        assert!(matches!(tome.run(source), Ok(Value::Int(27))));
+    }
+
+    #[test]
+    fn the_masking_import_is_not_a_regression_test_for_that() {
+        // Same tome, except the consumer also imports MARK. This passes with
+        // or without the fix, because the top-level import puts MARK in scope
+        // before the nested module is ever asked for it. Kept so that nobody
+        // writes only this shape and concludes the bug is gone.
+        let tome = TempTome::new("relconstmasked");
+        tome.write("tui/consts.sg", "≔ MARK = 27;")
+            .write("tui/user.sg", "invoke tome·consts·{MARK};\n☉ rite emit() -> i32 { MARK }");
+        let source = "\
+            invoke tome·tui·user·{emit};
+            invoke tome·tui·consts·{MARK};
+            rite main() { ⤺ emit(); }";
+        assert!(matches!(tome.run(source), Ok(Value::Int(27))));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`invoke tome·consts·{MARK}` inside `lib/user.sg` did not bind `MARK` for
`user.sg`. The identical modules one directory up worked.

`scroll` was taught to search the declaring file's own directory before the
tome root in #139. `invoke` was not — it resolved only against
`current_source_dir`, the tome root — so a module in a subdirectory could not
name the module beside it. This gives the `invoke` path the same search list,
declaring directory first, root second, for the reasons already recorded on the
`scroll` side: an `invoke` is relative, and the root stays in the list because
every flat tome depends on it.

One hunk in `process_use_tree`. Does not touch `eval_path`, so it does not
collide with #146.

## Why this went unnoticed, which is the interesting part

Two things hid it, and they compound.

**The failure is silent.** Not finding a module file returns `Ok(())`. Nothing
binds, nothing errors, `sigil check` passes. The first symptom is `undefined
variable` at a use site — which reads as a bug in the module, not in the loader.

**It disappears whenever the top-level program imports the same name.** That
puts the name in scope for everything, including the nested module whose own
binding never worked. The module then *works by coincidence*, and breaks for the
next consumer that does not happen to import its dependencies.

morgoth shipped in exactly that state. `src/tui/terminal.sg` does
`invoke tome·constants·{ESC}`; `terminal_init()` worked — but only because
`src/render.sg` independently imported the same constants. Its suite was green,
every module compiled, the application rendered correctly, **and the layer could
not be used by anything else.**

## Tests

`a_nested_module_binds_a_constant_from_its_sibling` is the regression test, and
its consumer **deliberately does not import the constant**. That shape is the
whole point — the masked form passes with or without this fix.

`the_masking_import_is_not_a_regression_test_for_that` pins that down: same
tome, consumer also imports the constant, passes either way. Kept so nobody
writes only that shape and concludes the bug is gone.

Constants are the gap rather than modules — the neighbouring nested-module
tests all cover `☉ rite`, and functions were already reached.

## Verified

**Rebased onto `develop` @ `652dc58`** (after #160 merged). The conflict was
textual only — both PRs append tests at the same point in `mod tests`, while
the production hunks never meet: mine is in `process_use_tree`, #160's is in
`eval_path`. Resolved keeping both sides; it needs the `#[test]` re-added
between them, because that attribute was shared *above* the marker and the
closing brace shared *below* it, so each side carries a brace delta of +1.

**Base:** `develop` @ `652dc58` (this branch: `c166bc3`).
**Features:** default (`jit, llvm, protocols, native`).
**Command:** `RUST_MIN_STACK=33554432 cargo test --release --no-fail-fast`

| binary | passed | failed |
|---|---|---|
| lib (`src/lib.rs`) | 592 | 2 |
| bin (`src/main.rs`) | 49 | 0 |
| **all binaries** | **641** | **2** (643 total) |

The two reds are the pre-existing
`llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}`. All six new
tests pass — #160's four and this PR's two.

`--no-fail-fast` matters and so does dropping `--lib`: cargo stops after the
first failing binary otherwise, and a lib-only figure silently omits the 49
tests in the bin target. An earlier revision of this note quoted 592/594, which
is the lib binary alone — correct for what it measured, and not the total.

For cross-checking against figures measured on `develop` @ `2a8f1a9`
(635 passed / 2 failed, 637 total): this branch's 643 is that plus #160's four
tests plus this PR's two, all six of which pass.

The unmasked test fails before this change and passes after; the masked one
passes both times, as documented.

### On feature flags and comparability

An earlier revision of this PR said "543/543" with no base or flags. Measured on
this commit by listing test names under each set:

| build | tests | vs default: dropped | vs default: added |
|---|---|---|---|
| default | 594 | — | — |
| `minimal,protocols` *(what produced the 543)* | 547 | **47** (all `llvm_codegen`) | **0** |
| `minimal,protocols,react-migrate,wasm` | 926 | 47 | **379** (231 `wasm`, 148 `migrate`) |

The two sets **overlap heavily and neither contains the other** — 547 tests are
common to both on this commit:

|  | default | four-flag |
|---|---|---|
| shared | 547 | 547 |
| only in this build | 47 (`llvm_codegen`) | 379 (231 `wasm`, 148 `migrate`) |
| **total** | **594** | **926** |

Two different problems, worth not conflating:

- `minimal,protocols` is a **strict subset** of default: the same 47 dropped, 0
  added. Every test in it is a real test, but both known reds are among the
  missing 47 — so `543/543` was all-green *because* the failures had not been
  built. A false green, and the number said nothing about it.
- `minimal,protocols,react-migrate,wasm` is **not a subset in either
  direction**: it omits the same 47 (both reds with them) and adds 379 that a
  default build never compiles. Its totals are not comparable to a default
  total either way, and a clean 920/0 from it still hides the two failures the
  PRs disclose.

An earlier revision of this note called that second case "disjoint". That was
wrong — the sets share 547 tests. The load-bearing property is that neither is
a superset of the other, which is a weaker and more precise claim, and the one
that actually makes the counts incomparable.

The remedy differs — a subset under-reports; a disjoint set reports something
else — which is why the distinction is here rather than a single "minimal flags
are wrong" note.

Against morgoth, whose reusable-layer finding this unblocks:

| | before | after |
|---|---|---|
| `terminal_init()` via `tome·tui·terminal`, caller imports no constants | `undefined variable: ESC` | OK |
| `render_border()` via `tome·tui·draw`, same | `undefined variable: BOX_H` | `┌` |

The full `src/tui/` layer copied into an empty directory **with no morgoth
module present** now runs a non-morgoth program end to end — layout, border,
`fill_row`, vterm feed + blit, text overlay. morgoth's own suite: **239/239,
exit 0, twice** (morgoth's runner prints its own compiler provenance per run).

## Notes

Based on `develop` @ `2a8f1a9`. #146 was not yet merged when this branched, so
expect a trivial add/add in the test region around the nested-module tests —
coordinated with that session in advance; the fixes themselves are in different
functions.

Closes #152 (needs closing by hand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ro5Vh8CBXbKem2Yru121Ci





