### PR TITLE
fix(migrate): carry the helpers a module constant's initialiser calls

### DIFF
--- a/parser/src/migrate/react/mcp.rs
+++ b/parser/src/migrate/react/mcp.rs
@@ -364,6 +364,62 @@ impl MigrationSession {
             merged.append(&mut comp.source.module_constants);
             comp.source.module_constants = merged;
 
+            // constant -> helper. The walks above cover helper->helper,
+            // constant->constant and helper->constant; this is the fourth edge
+            // and it was missing. A helper that only a module constant's
+            // INITIALISER calls is in nobody's `module_scope`, and no helper
+            // body names it either, so nothing queued it:
+            //
+            //   export const BUILTIN_THEMES = {
+            //     "daemoniorum": { modes: { dark: daemoniorumTheme("dark") } },
+            //     …
+            //   }
+            //
+            // `BUILTIN_THEMES` is exported, reached and emitted; the five theme
+            // builders it calls were not, and each call compiled to a constant
+            // 0. This is S119 in the other direction — that one added the
+            // constants a helper's body names, and left the helpers a
+            // constant's initialiser names.
+            let mut reachable_helpers = reachable_helpers;
+            {
+                let mut have_h: std::collections::HashSet<String> = reachable_helpers
+                    .iter()
+                    .map(|h| h.name.clone())
+                    .chain(comp.source.helpers.iter().map(|h| h.name.clone()))
+                    .collect();
+                let mut seeds: Vec<String> = Vec::new();
+                // The component's full constant set, imported and own: a
+                // constant declared in the component's own file has the same
+                // edge, and `module_constants` is the merged list by here.
+                for c in &comp.source.module_constants {
+                    for word in c
+                        .init
+                        .split(|ch: char| !(ch.is_alphanumeric() || ch == '_' || ch == '$'))
+                    {
+                        if !word.is_empty()
+                            && !have_h.contains(word)
+                            && (helpers.contains_key(word) || deep_helpers.contains_key(word))
+                        {
+                            have_h.insert(word.to_string());
+                            seeds.push(word.to_string());
+                        }
+                    }
+                }
+                if !seeds.is_empty() {
+                    let from_constants = Self::reachable_helpers_from(
+                        seeds,
+                        comp.source.helpers.iter().map(|h| h.name.clone()).collect(),
+                        &helpers,
+                        &deep_helpers,
+                    );
+                    for h in from_constants {
+                        if !reachable_helpers.iter().any(|e| e.name == h.name) {
+                            reachable_helpers.push(h);
+                        }
+                    }
+                }
+            }
+
             // Helpers, computed above: a helper's own body may reference
             // another helper, so that walk is transitive too.
             let added_h = reachable_helpers;
@@ -395,9 +451,24 @@ impl MigrationSession {
         exported: &HashMap<String, HelperFunctionExtraction>,
         all: &HashMap<String, HelperFunctionExtraction>,
     ) -> Vec<HelperFunctionExtraction> {
-        let mut have: std::collections::HashSet<String> =
+        let have: std::collections::HashSet<String> =
             source.helpers.iter().map(|h| h.name.clone()).collect();
-        let mut queue: Vec<String> = source.module_scope.clone();
+        Self::reachable_helpers_from(source.module_scope.clone(), have, exported, all)
+    }
+
+    /// The same walk from an explicit seed list, with an explicit "already
+    /// have" set.
+    ///
+    /// Split out for the constant→helper edge: a helper that only a module
+    /// constant's initialiser calls is in nobody's `module_scope`, so the
+    /// seeded walk above never reaches it.
+    fn reachable_helpers_from(
+        seeds: Vec<String>,
+        mut have: std::collections::HashSet<String>,
+        exported: &HashMap<String, HelperFunctionExtraction>,
+        all: &HashMap<String, HelperFunctionExtraction>,
+    ) -> Vec<HelperFunctionExtraction> {
+        let mut queue: Vec<String> = seeds;
         let mut added: Vec<HelperFunctionExtraction> = Vec::new();
         let mut guard = 0;
         while let Some(name) = queue.pop() {
@@ -939,4 +1010,91 @@ pub fn topo_sort_constants(items: Vec<ModuleConstantExtraction>) -> Vec<ModuleCo
         out.push(items[i].clone());
     }
     out
+}
+
+#[cfg(test)]
+mod constant_to_helper_tests {
+    use super::*;
+    use crate::migrate::react::extraction::{
+        HelperFunctionExtraction, ModuleConstantExtraction, SourceLocation,
+    };
+
+    fn helper(name: &str, source: &str, exported: bool) -> HelperFunctionExtraction {
+        HelperFunctionExtraction {
+            name: name.to_string(),
+            location: SourceLocation { start_line: 0, start_col: 0, end_line: 0, end_col: 0 },
+            exported,
+            is_async: false,
+            is_generator: false,
+            parameters: Vec::new(),
+            return_type: None,
+            is_pure: true,
+            side_effects: Vec::new(),
+            calls: Vec::new(),
+            used_by: Vec::new(),
+            source: source.to_string(),
+            returns_expression: None,
+        }
+    }
+
+    fn constant(name: &str, init: &str) -> ModuleConstantExtraction {
+        ModuleConstantExtraction {
+            name: name.to_string(),
+            exported: true,
+            type_annotation: None,
+            init: init.to_string(),
+            entries: Vec::new(),
+        }
+    }
+
+    /// A helper reached only from a module constant's initialiser.
+    ///
+    /// `BUILTIN_THEMES` is exported and emitted; `daemoniorumTheme` is called
+    /// only from inside its object literal, is in nobody's `module_scope`, and
+    /// no helper body names it. Before the constant->helper edge it was never
+    /// carried, and the call compiled to a constant 0.
+    #[test]
+    fn helper_named_only_by_a_constant_initialiser_is_reached() {
+        let mut all = HashMap::new();
+        all.insert(
+            "daemoniorumTheme".to_string(),
+            helper("daemoniorumTheme", "function daemoniorumTheme(mode) { return pickAccent(mode) }", false),
+        );
+        // …and transitively, what that helper itself calls.
+        all.insert(
+            "pickAccent".to_string(),
+            helper("pickAccent", "function pickAccent(m) { return m }", false),
+        );
+        let exported: HashMap<String, HelperFunctionExtraction> = HashMap::new();
+
+        let c = constant(
+            "BUILTIN_THEMES",
+            r#"{ "daemoniorum": { modes: { dark: daemoniorumTheme("dark") } } }"#,
+        );
+
+        // The seeding this fix added: scan the constant's initialiser for names
+        // that are helpers, then expand transitively.
+        let mut seeds = Vec::new();
+        for word in c
+            .init
+            .split(|ch: char| !(ch.is_alphanumeric() || ch == '_' || ch == '$'))
+        {
+            if !word.is_empty() && all.contains_key(word) {
+                seeds.push(word.to_string());
+            }
+        }
+        assert_eq!(seeds, vec!["daemoniorumTheme".to_string()], "constant initialiser must seed the helper");
+
+        let reached = MigrationSession::reachable_helpers_from(
+            seeds,
+            std::collections::HashSet::new(),
+            &exported,
+            &all,
+        );
+        let names: std::collections::HashSet<&str> =
+            reached.iter().map(|h| h.name.as_str()).collect();
+
+        assert!(names.contains("daemoniorumTheme"), "helper named by the constant");
+        assert!(names.contains("pickAccent"), "and what it calls, transitively");
+    }
 }

--- a/parser/src/migrate/react/mcp.rs
+++ b/parser/src/migrate/react/mcp.rs
@@ -1015,15 +1015,65 @@ pub fn topo_sort_constants(items: Vec<ModuleConstantExtraction>) -> Vec<ModuleCo
 #[cfg(test)]
 mod constant_to_helper_tests {
     use super::*;
-    use crate::migrate::react::extraction::{
-        HelperFunctionExtraction, ModuleConstantExtraction, SourceLocation,
-    };
 
-    fn helper(name: &str, source: &str, exported: bool) -> HelperFunctionExtraction {
+    /// A component built through `serde`, so the fixture cannot drift from the
+    /// real struct: adding a field to `ComponentMigrationSpec` breaks this
+    /// loudly rather than leaving the test constructing a stale shape.
+    ///
+    /// Only the three fields `resolve_cross_module_imports` reads are
+    /// interesting — `module_scope`, `module_constants` and `helpers`.
+    fn component(
+        module_scope: &[&str],
+        module_constants: Vec<ModuleConstantExtraction>,
+        helpers: Vec<HelperFunctionExtraction>,
+    ) -> ComponentMigrationSpec {
+        let mut v = serde_json::json!({
+            "id": "c1",
+            "name": "Themed",
+            "source": {
+                "path": "src/themed.tsx",
+                "code": "",
+                "extraction": {
+                    "name": "Themed",
+                    "component_type": "functional",
+                    "exported": true,
+                    "export_type": null,
+                    "location": { "start_line": 0, "start_col": 0, "end_line": 0, "end_col": 0 },
+                    "props": [],
+                    "props_type": null,
+                    "hooks": [],
+                    "custom_hooks": [],
+                    "class_info": null,
+                    "jsx": { "root": null },
+                    "handlers": [],
+                    "child_components": []
+                },
+                "module_scope": module_scope,
+            },
+            "target": { "suggested_path": "themed.sigil", "pattern": "function" },
+            "recommendations": {
+                "state_fields": [], "messages": [], "effects": [],
+                "props_handling": { "strategy": "none", "fields": [] }
+            },
+            "patterns": [],
+            "ambiguities": [],
+            "dependencies": { "components": [], "types": [] },
+            "complexity": "simple",
+            "complexity_factors": [],
+            "status": "pending"
+        });
+        let mut c: ComponentMigrationSpec =
+            serde_json::from_value(v.take()).expect("fixture must match the real struct");
+        c.source.module_constants = module_constants;
+        c.source.helpers = helpers;
+        c
+    }
+
+    fn helper(name: &str, source: &str) -> HelperFunctionExtraction {
         HelperFunctionExtraction {
             name: name.to_string(),
             location: SourceLocation { start_line: 0, start_col: 0, end_line: 0, end_col: 0 },
-            exported,
+            exported: false,
             is_async: false,
             is_generator: false,
             parameters: Vec::new(),
@@ -1047,54 +1097,122 @@ mod constant_to_helper_tests {
         }
     }
 
-    /// A helper reached only from a module constant's initialiser.
+    /// Drive the REAL entry point, not the walk underneath it.
     ///
-    /// `BUILTIN_THEMES` is exported and emitted; `daemoniorumTheme` is called
-    /// only from inside its object literal, is in nobody's `module_scope`, and
-    /// no helper body names it. Before the constant->helper edge it was never
-    /// carried, and the call compiled to a constant 0.
+    /// The previous version of this test reimplemented the seeding loop inline
+    /// and then called `reachable_helpers_from` directly, so the production
+    /// seeding block was never executed and mutating it left the test green.
+    /// Everything here goes through `resolve_cross_module_imports`.
+    fn resolve(
+        comp: ComponentMigrationSpec,
+        all_helpers: Vec<HelperFunctionExtraction>,
+        all_constants: Vec<ModuleConstantExtraction>,
+    ) -> ComponentMigrationSpec {
+        let dir = std::env::temp_dir();
+        let mut s = MigrationSession::new(&dir, &dir).expect("session");
+        s.spec.components = vec![comp];
+        s.all_helpers = all_helpers.into_iter().map(|h| (h.name.clone(), h)).collect();
+        s.all_constants = all_constants.into_iter().map(|c| (c.name.clone(), c)).collect();
+        // Nothing is exported: every name here has to travel by reachability
+        // rather than by being an import specifier.
+        s.exported_helpers = HashMap::new();
+        s.exported_constants = HashMap::new();
+        s.resolve_cross_module_imports();
+        s.spec.components.remove(0)
+    }
+
+    fn helper_names(c: &ComponentMigrationSpec) -> std::collections::HashSet<String> {
+        c.source.helpers.iter().map(|h| h.name.clone()).collect()
+    }
+    fn constant_names(c: &ComponentMigrationSpec) -> std::collections::HashSet<String> {
+        c.source.module_constants.iter().map(|c| c.name.clone()).collect()
+    }
+
+    /// The fourth edge: a helper named only by a module constant's initialiser.
+    ///
+    /// `BUILTIN_THEMES` is the component's own constant. `daemoniorumTheme` is
+    /// called only from inside its object literal, is in nobody's
+    /// `module_scope`, and no helper body names it. Before the constant→helper
+    /// edge nothing queued it and the call compiled to a constant 0.
     #[test]
-    fn helper_named_only_by_a_constant_initialiser_is_reached() {
-        let mut all = HashMap::new();
-        all.insert(
-            "daemoniorumTheme".to_string(),
-            helper("daemoniorumTheme", "function daemoniorumTheme(mode) { return pickAccent(mode) }", false),
+    fn a_helper_named_only_by_a_constant_initialiser_is_carried() {
+        let comp = component(
+            &[],
+            vec![constant(
+                "BUILTIN_THEMES",
+                r#"{ "daemoniorum": { modes: { dark: daemoniorumTheme("dark") } } }"#,
+            )],
+            vec![],
         );
-        // …and transitively, what that helper itself calls.
-        all.insert(
-            "pickAccent".to_string(),
-            helper("pickAccent", "function pickAccent(m) { return m }", false),
-        );
-        let exported: HashMap<String, HelperFunctionExtraction> = HashMap::new();
-
-        let c = constant(
-            "BUILTIN_THEMES",
-            r#"{ "daemoniorum": { modes: { dark: daemoniorumTheme("dark") } } }"#,
+        let out = resolve(
+            comp,
+            vec![
+                helper("daemoniorumTheme", "function daemoniorumTheme(mode) { return pickAccent(mode) }"),
+                helper("pickAccent", "function pickAccent(m) { return m }"),
+            ],
+            vec![],
         );
 
-        // The seeding this fix added: scan the constant's initialiser for names
-        // that are helpers, then expand transitively.
-        let mut seeds = Vec::new();
-        for word in c
-            .init
-            .split(|ch: char| !(ch.is_alphanumeric() || ch == '_' || ch == '$'))
-        {
-            if !word.is_empty() && all.contains_key(word) {
-                seeds.push(word.to_string());
-            }
-        }
-        assert_eq!(seeds, vec!["daemoniorumTheme".to_string()], "constant initialiser must seed the helper");
+        let got = helper_names(&out);
+        assert!(got.contains("daemoniorumTheme"), "helper named by the constant initialiser, got {got:?}");
+        assert!(got.contains("pickAccent"), "and what that helper calls, transitively, got {got:?}");
+        // The carried helpers must also be declared, or the generator rewrites
+        // the call to `self.daemoniorum_theme` and nothing declares that.
+        assert!(out.source.module_scope.contains(&"daemoniorumTheme".to_string()));
+        assert!(out.source.module_functions.contains(&"daemoniorumTheme".to_string()));
+    }
 
-        let reached = MigrationSession::reachable_helpers_from(
-            seeds,
-            std::collections::HashSet::new(),
-            &exported,
-            &all,
+    /// A helper reached ONLY through the constant→helper edge must contribute
+    /// its own constants, and those constants their own helpers.
+    ///
+    /// The chain is constant → helper → constant → helper:
+    ///
+    ///   SEED_TABLE      (the component's own constant) names `buildRow`
+    ///   buildRow        (helper)                       names `ROW_DEFAULTS`
+    ///   ROW_DEFAULTS    (constant)                     names `defaultCell`
+    ///   defaultCell     (helper)
+    ///
+    /// The constant walk is seeded from the helper set computed before the
+    /// constant→helper edge runs, and closes before it. So a helper discovered
+    /// through a constant contributes no constants of its own, and anything
+    /// behind those constants is unreachable.
+    /// MEASURED FAILING, and kept rather than deleted. The implementation is
+    /// ABSENT, not flaky: this cannot pass until the walks reach a fixpoint.
+    ///
+    /// Run it today and hop 2 fails with `got constants {"SEED_TABLE"}` —
+    /// `ROW_DEFAULTS` never arrives, so `defaultCell` behind it cannot either.
+    /// That is a real gap in the same family as the one this PR closes, one
+    /// edge further out, and it is out of scope here: fixing it means running
+    /// the constant walk and the constant->helper walk to a fixpoint rather
+    /// than once each, which is a change to the shape of the function rather
+    /// than an added edge.
+    #[test]
+    #[ignore = "measured gap: a helper found via a constant contributes no constants of its own"]
+    fn a_helper_found_through_a_constant_contributes_its_own_constants() {
+        let comp = component(
+            &[],
+            vec![constant("SEED_TABLE", "{ row: buildRow() }")],
+            vec![],
         );
-        let names: std::collections::HashSet<&str> =
-            reached.iter().map(|h| h.name.as_str()).collect();
+        let out = resolve(
+            comp,
+            vec![
+                helper("buildRow", "function buildRow() { return ROW_DEFAULTS }"),
+                helper("defaultCell", "function defaultCell() { return 0 }"),
+            ],
+            vec![constant("ROW_DEFAULTS", "{ cell: defaultCell() }")],
+        );
 
-        assert!(names.contains("daemoniorumTheme"), "helper named by the constant");
-        assert!(names.contains("pickAccent"), "and what it calls, transitively");
+        let h = helper_names(&out);
+        let c = constant_names(&out);
+        assert!(h.contains("buildRow"), "hop 1: helper named by the seed constant, got {h:?}");
+        assert!(
+            c.contains("ROW_DEFAULTS"),
+            "hop 2: the constant that helper's body names must be carried, got constants {c:?}"
+        );
+        assert!(
+            h.contains("defaultCell"),
+            "hop 3: the helper that constant's initialiser names must be carried, got helpers {h:?}"
+        );
     }
 }


### PR DESCRIPTION
The reachability walk had three edges and needed four. `helper→helper`, `constant→constant` and `helper→constant` were all there; **`constant→helper` was not.**

A helper that only a module constant's *initialiser* calls is in nobody's `module_scope`, and no helper body names it, so nothing ever queued it:

```ts
export const BUILTIN_THEMES: Record<BuiltinThemeId, ThemeDefinition> = {
  "daemoniorum": { modes: { dark: daemoniorumTheme("dark"), light: daemoniorumTheme("light") } },
  "lightspeed":  { modes: { dark: lightspeedTheme("dark"),  light: lightspeedTheme("light")  } },
  "sigil":       { modes: { dark: sigilTheme() } },
}
```

`BUILTIN_THEMES` is exported, reached and emitted. The five builders it calls are not — and each call compiled to a constant `0`, so the whole theme subsystem of the migrated client returned `0` while `sigil wasm` exited 0 and printed `Successfully compiled`.

**This is S119 in the other direction.** That one added the constants a helper's body names; it left the helpers a constant's initialiser names.

## The fix

Seed a second helper walk from the names a component's module constants mention, and expand it transitively — a helper reached that way can call others. It scans the **merged** constant set rather than only the imported one, so a constant declared in the component's own file gets the same edge.

`reachable_helper_set` is split into a seeded variant, `reachable_helpers_from`, which the existing walk now calls too. No behaviour change on the existing path.

## Measured

`Daemoniorum-LLC/lares-client` at `develop`, React input `lares` `main` @ `634034d`:

| | |
|---|---|
| before | **5** calls compiled to a constant `0`; link exit 0 with a warning |
| after | **0**; the warning is gone entirely |

## Two wrong diagnoses first, both worth recording

Both were characterised from a sample rather than measured.

1. *"File-private helpers in an `--include-source` directory are never emitted."* **False.** Four file-private helpers from that same file do arrive, and export status does not predict emission at all — 16 exported+emitted, 4 private+emitted, 12 private+missing, and the four "exported+missing" turned out to be my own snake_case conversion being wrong.
2. An intermediate census said **0 of 36** `themes.ts` functions were emitted. That was an artefact of my tooling: the generated `shared.sigil` contains **4 NUL bytes**, so `grep` treated it as binary and silently printed nothing, and I read the silence as a negative result. With `grep -a` it is 20 of 36.

Those NUL bytes are a separate defect, filed separately. (The silence-read-as-negative is the same shape as #131, third instance today.)

## Tests

Provenance line for every count below: **`sigil-lang` `develop` @ `2a8f1a9`, `cargo test --release --no-fail-fast`, feature set named per row.** The flag set is part of the provenance, not a footnote — the counts move by hundreds between sets.

**Default features, all binaries** — the number that should be quoted:

| | this branch | baseline `2a8f1a9` |
|---|---|---|
| all binaries | **635 passed, 2 failed**, exit 101 | 635 passed, 2 failed, exit 101 |
| lib only | 586 passed, 2 failed | 586 passed, 2 failed |

**Identical before and after.** The two failures are `llvm_codegen::llvm::tests::test_generic_struct_basic` and `test_generic_struct_two_params`, both pre-existing on unmodified `develop`.

### Why this PR does not quote a minimal-flags number as its headline

Because a clean result under either minimal set is a **false green**, and this repo's PR bodies have been carrying them:

| feature set | lib | all binaries | omits |
|---|---|---|---|
| default | 586 / **2 fail** | 635 / **2 fail** | 379 wasm + migrate tests |
| `minimal,protocols` | 541 / 0 | 590 / 0 | **all 47 `llvm_codegen`, where both failures live** |
| `minimal,protocols,react-migrate,wasm` | 920 / 0 | 969 / 0 | **the same 47** |

The two minimal sets report 0 failures because neither builds `llvm_codegen` at all. **Neither set is a superset of the other** — default and the four-flag set share 541 tests, default adds 47 `llvm_codegen`, the four-flag set adds 379 wasm and migrate — so the counts are not comparable in either direction.

For completeness, since this change lives in `migrate::react`, which default features do **not** build: under `minimal,protocols,react-migrate,wasm` this branch is **920 passed, 0 failed** against a baseline of 919, the +1 being the regression test below. That number covers the changed code and is *not* evidence the suite is green.

Two further notes for anyone re-running this:

- **Use `--no-fail-fast`.** Without it cargo stops after the first failing binary and reports 586, which is itself the narrower answer to the narrower question. The complete figure is 635 of 637.
- **Use `--release`.** In a debug build `stdlib::tests::test_parser_nested_brackets` overflows its stack and aborts the whole run under *both* flag sets on unmodified `develop`, so `--lib` needs `--skip` there. `--release` does not hit it.

*(An earlier revision of this body said the two flag sets were "disjoint" and quoted a fail-fast-truncated 585. Both were wrong; corrected above. The 585 came from a debug run with the aborting test skipped.)*

55 bundled examples A/B'd through `sigil wasm`: **0 regressions**.

A regression test pins the edge directly — a constant initialiser naming a helper must seed it, and what that helper calls must arrive transitively.

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

