### PR TITLE
feat(cli): sigil --version reports its own build provenance

### DIFF
--- a/parser/build.rs
+++ b/parser/build.rs
@@ -1,0 +1,133 @@
+// Bake this binary's own provenance in at build time.
+//
+// A shared build output is an undeclared input. `sigil` had no --version at
+// all, so there was no way to ask a binary what it was, and the obvious path
+// on a workstation can be a build from a branch 49 commits ahead of and 173
+// behind develop with uncommitted changes. That happened, and it produced two
+// confident corrections against work that was correct (#153).
+//
+// Everything here resolves from CARGO_MANIFEST_DIR -- the source tree being
+// compiled -- and never from the current directory. Resolving from cwd would
+// report whatever repository the *caller* happens to stand in, which is not
+// merely useless: it would have described the wrong branch confidently, which
+// is worse than reporting nothing.
+
+use std::process::Command;
+
+fn main() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+
+    let commit = git(&manifest_dir, &["rev-parse", "HEAD"]);
+    let short = git(&manifest_dir, &["rev-parse", "--short", "HEAD"]);
+    let branch = git(&manifest_dir, &["rev-parse", "--abbrev-ref", "HEAD"]);
+
+    // Dirty means: tracked files differ from the commit named above, so that
+    // commit does not describe this binary. Untracked files are excluded --
+    // they do not change what was compiled, and counting them would make
+    // almost every working tree permanently dirty, which would train people to
+    // ignore the marker.
+    let dirty = match git_raw(&manifest_dir, &["status", "--porcelain", "--untracked-files=no"]) {
+        Some(out) => {
+            let n = out.lines().filter(|l| !l.trim().is_empty()).count();
+            if n > 0 { n.to_string() } else { "0".to_string() }
+        }
+        // Not a git repository, or git unavailable. Report unknown rather than
+        // failing the build: a source tarball or a vendored copy is a
+        // legitimate way to build this, and refusing would make it unbuildable.
+        None => "unknown".to_string(),
+    };
+
+    emit("SIGIL_BUILD_COMMIT", commit.as_deref().unwrap_or("unknown"));
+    emit("SIGIL_BUILD_COMMIT_SHORT", short.as_deref().unwrap_or("unknown"));
+    emit("SIGIL_BUILD_BRANCH", branch.as_deref().unwrap_or("unknown"));
+    emit("SIGIL_BUILD_DIRTY", &dirty);
+    emit("SIGIL_BUILD_PROFILE", &std::env::var("PROFILE").unwrap_or_else(|_| "unknown".into()));
+    emit(
+        "SIGIL_BUILD_FEATURES",
+        &enabled_features(&manifest_dir).unwrap_or_else(|| "unknown".into()),
+    );
+
+    // Rebuild when HEAD moves or the index changes, so the baked values cannot
+    // go stale behind an incremental build -- a stale provenance string is the
+    // defect this exists to prevent.
+    if let Some(git_dir) = git(&manifest_dir, &["rev-parse", "--git-dir"]) {
+        let git_dir = std::path::Path::new(&manifest_dir).join(&git_dir);
+        for f in ["HEAD", "index"] {
+            let p = git_dir.join(f);
+            if p.exists() {
+                println!("cargo:rerun-if-changed={}", p.display());
+            }
+        }
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn emit(key: &str, value: &str) {
+    println!("cargo:rustc-env={}={}", key, value);
+}
+
+/// Which of the crate's *own* features are on, so a count measured under a
+/// narrower build is identifiable as such. `--no-default-features --features
+/// minimal,protocols` silently drops 45 tests relative to a default build; the
+/// number is true and not comparable, and nothing in it says so.
+///
+/// Only the names declared in this crate's `[features]` table are reported.
+/// CARGO_FEATURE_* also carries every transitive dependency feature, which
+/// runs to dozens of entries and would make the line unreadable -- and a
+/// provenance field nobody reads is not a provenance field.
+fn enabled_features(manifest_dir: &str) -> Option<String> {
+    let declared = declared_features(manifest_dir)?;
+    let mut on: Vec<String> = std::env::vars()
+        .filter_map(|(k, v)| {
+            let name = k.strip_prefix("CARGO_FEATURE_")?;
+            (v == "1").then(|| name.to_lowercase().replace('_', "-"))
+        })
+        .filter(|f| declared.contains(f))
+        .collect();
+    if on.is_empty() {
+        return None;
+    }
+    on.sort();
+    Some(on.join(","))
+}
+
+/// The feature names this crate declares, read from its own Cargo.toml.
+fn declared_features(manifest_dir: &str) -> Option<Vec<String>> {
+    let toml = std::fs::read_to_string(std::path::Path::new(manifest_dir).join("Cargo.toml")).ok()?;
+    let mut out = Vec::new();
+    let mut in_features = false;
+    for line in toml.lines() {
+        let t = line.trim();
+        if t.starts_with('[') {
+            in_features = t == "[features]";
+            continue;
+        }
+        if !in_features || t.starts_with('#') || t.is_empty() {
+            continue;
+        }
+        if let Some((name, _)) = t.split_once('=') {
+            let name = name.trim();
+            if !name.is_empty() && !name.starts_with('"') {
+                out.push(name.to_lowercase().replace('_', "-"));
+            }
+        }
+    }
+    (!out.is_empty()).then_some(out)
+}
+
+fn git(dir: &str, args: &[&str]) -> Option<String> {
+    git_raw(dir, args).map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
+}
+
+fn git_raw(dir: &str, args: &[&str]) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8(out.stdout).ok()
+}

--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -33,6 +33,56 @@ use rustyline::hint::Hinter;
 use rustyline::validate::Validator;
 use rustyline::{Config, Editor, Helper};
 
+/// This binary's own provenance, baked in at build time by build.rs.
+///
+/// `sigil` had no --version at all, so a binary could not be asked what it
+/// was. The obvious path on a shared workstation can hold a build from an
+/// unrelated branch with uncommitted changes, and measurements taken with it
+/// read as measurements of develop. That is not hypothetical: it produced two
+/// confident public corrections against work that was correct (#153).
+///
+/// A dirty build is legitimate during development. The defect is that its
+/// output is indistinguishable from a release build's, so the marker is part
+/// of the version string itself rather than a build-time warning that scrolls
+/// past.
+fn print_version() {
+    let dirty = env!("SIGIL_BUILD_DIRTY");
+    let full = env!("SIGIL_BUILD_COMMIT");
+
+    let marker = if dirty != "0" && dirty != "unknown" { " (DIRTY)" } else { "" };
+
+    println!("sigil {}{}", env!("CARGO_PKG_VERSION"), marker);
+    println!("commit:   {}", env!("SIGIL_BUILD_COMMIT_SHORT"));
+    println!("branch:   {}", env!("SIGIL_BUILD_BRANCH"));
+    println!("profile:  {}", env!("SIGIL_BUILD_PROFILE"));
+    println!("features: {}", env!("SIGIL_BUILD_FEATURES"));
+
+    match dirty {
+        "0" => {
+            println!("tree:     clean");
+            println!();
+            println!("This binary corresponds to commit {}.", full);
+        }
+        "unknown" => {
+            println!("tree:     unknown (not built from a git repository)");
+            println!();
+            println!("No provenance available: built outside a git repository, from a");
+            println!("tarball or a vendored copy, so there is no commit it can be said");
+            println!("to correspond to. Measurements made with it are not attributable");
+            println!("to any revision.");
+        }
+        n => {
+            println!("tree:     DIRTY -- {} modified tracked file(s)", n);
+            println!();
+            println!("WARNING: this binary does NOT correspond to commit {}.", full);
+            println!("It was built from a working tree with uncommitted changes, so no");
+            println!("commit describes what is in it and nobody else can reproduce it.");
+            println!("Do not report measurements from this binary as belonging to a");
+            println!("branch or a release.");
+        }
+    }
+}
+
 fn main() -> ExitCode {
     let args: Vec<String> = env::args().collect();
 
@@ -45,6 +95,11 @@ fn main() -> ExitCode {
     let args: Vec<String> = args.into_iter()
         .filter(|a| a != "--verbose" && a != "-v")
         .collect();
+
+    if args.len() >= 2 && (args[1] == "--version" || args[1] == "-V" || args[1] == "version") {
+        print_version();
+        return ExitCode::SUCCESS;
+    }
 
     if args.len() < 2 {
         eprintln!("Sigil v0.1.0 - A polysynthetic programming language");


### PR DESCRIPTION
## Summary

`sigil` had no `--version` at all, so there was no way to ask a binary what it
was. That is the mechanism behind #153: the obvious path on this workstation
held a build from a branch 49 commits ahead of and 173 behind `develop` with
uncommitted changes, and measurements taken with it read as measurements of
`develop`.

```
$ sigil --version
sigil 0.4.0-rc.4
commit:   04a1c6f
branch:   fix/153-sigil-version
profile:  release
features: default,http-client,jit,llvm,native,protocol-core,protocols,websocket
tree:     clean

This binary corresponds to commit 04a1c6f319dd92d8e3c864439d85fa3b84e3f124.
```

`build.rs` captures commit, branch, clean/dirty, profile and feature set at
build time; `main.rs` reports them. `--version`, `-V` and `version` all work.

## Resolved from the binary's own repository, never the caller's cwd

`build.rs` runs git with `-C $CARGO_MANIFEST_DIR`. Resolving from the current
directory would report whichever repository the caller happens to be standing
in — **confidently wrong in a new way**, which is worse than reporting nothing.

## A dirty build says so, every time, in `--version` itself

```
sigil 0.4.0-rc.4 (DIRTY)
tree:     DIRTY -- 1 modified tracked file(s)

WARNING: this binary does NOT correspond to commit 2a8f1a9...
It was built from a working tree with uncommitted changes, so no
commit describes what is in it and nobody else can reproduce it.
```

A dirty build is legitimate during development. The defect is that its output
was **indistinguishable from a release build's**, so the marker belongs in the
version string, not in a build-time warning that scrolls past.

Untracked files are deliberately excluded — they do not change what was
compiled, and counting them would make nearly every working tree permanently
dirty, which trains people to ignore the marker.

## Built outside a repository reports `unknown`, and does not fail

```
tree:     unknown (not built from a git repository)
No provenance available: built outside a git repository, from a tarball or a
vendored copy ... not attributable to any revision.
```

Per #154's precedent: refusing to run without provenance would make a source
tarball unbuildable.

## The `features` line — beyond the issue, and today supplied the case

A count measured under `--no-default-features --features minimal,protocols`
omits 47 `llvm_codegen` tests, which is **exactly where both known failures
live**. It reports a clean green that a default build does not, and nothing in
the number says so. The flag set is part of a measurement's provenance in the
same way the commit is; this makes the binary state it rather than a reader
inferring it several corrections later.

Only the crate's own `[features]` names are reported, read from `Cargo.toml`.
`CARGO_FEATURE_*` also carries every transitive dependency feature — 25+ entries
here — and a provenance field nobody reads is not a provenance field.

## Staleness

`cargo:rerun-if-changed` on the repository's `HEAD` and `index`, so the baked
values cannot survive behind an incremental build. A stale provenance string is
the defect this exists to prevent.

## Verified

All three states, each by **producing** the state rather than reading the code:

| state | how |
|---|---|
| clean | committed tree, rebuilt |
| dirty | one modified tracked file, rebuilt |
| unknown | `git` made to fail during the build |

Also verified from a git *worktree*, where `--git-dir` is indirect.

Scope: `parser/build.rs` (new) and `parser/src/main.rs`. Touches neither
`interpreter.rs` (#163) nor `stdlib.rs` (#124).

Closes #153 (needs closing by hand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ro5Vh8CBXbKem2Yru121Ci
