### PR TITLE
fix(stdlib): open a real socket, and make the calls on it do what they report

### DIFF
--- a/jormungandr/tests/spec/22_native_runtime/P1_041_socket_connect.expected
+++ b/jormungandr/tests/spec/22_native_runtime/P1_041_socket_connect.expected
@@ -1,6 +1,8 @@
 socket: OK
 connect: OK
 send: OK
-recv: OK
+payload arrived intact: OK
+reply arrived intact: OK
 shutdown: OK
+peer saw EOF: OK
 close: OK

--- a/jormungandr/tests/spec/22_native_runtime/P1_041_socket_connect.sg
+++ b/jormungandr/tests/spec/22_native_runtime/P1_041_socket_connect.sg
@@ -1,54 +1,57 @@
-// Test socket connect operations
-// This tests the native runtime networking syscalls
+// Test: socket connect, send, recv, shutdown
+// Spec: 22-NATIVE-RUNTIME.md
 // Priority: P1
+//
+// A real connection over loopback, with the payload compared rather than
+// counted. This file used to say "in interpreter mode, this always succeeds"
+// and "Send some data (simulated)" in its own comments: `Sys·send` returned
+// the length it was handed without reading the buffer, and `Sys·recv` returned
+// 0, so `sent == 5` and `received >= 0` passed while nothing crossed a socket
+// (#124, #167).
+//
+// Asserting a plausible number is exactly the defect being fixed, so every
+// assertion here is about bytes that arrived.
 
 rite main() {
-    // Test: Create and connect a TCP socket (simulated)
-    ≔ sock = Sys·socket(AF_INET(), SOCK_STREAM(), 0);
+    ≔ srv = Sys·socket(2, 1, 0);
+    Sys·setsockopt(srv, 1, 2, 1, 4);
+    Sys·bind(srv, "127.0.0.1:7432", 0);
+    Sys·listen(srv, 8);
 
-    ⎇ sock >= 0 {
-        println("socket: OK");
+    ≔ cli = Sys·socket(2, 1, 0);
+    ⎇ cli < 0 { println("socket: FAILED"); ⤺; }
+    println("socket: OK");
 
-        // Connect (in interpreter mode, this always succeeds)
-        ≔ result = Sys·connect(sock, 0, 16);
-        ⎇ result == 0 {
-            println("connect: OK");
+    ⎇ Sys·connect(cli, "127.0.0.1:7432", 0) == 0 {
+        println("connect: OK");
+    } ⎉ { println("connect: FAILED"); ⤺; }
 
-            // Send some data (simulated)
-            ≔ sent = Sys·send(sock, 0, 5, 0);
-            ⎇ sent == 5 {
-                println("send: OK");
-            } ⎉ {
-                println("send: FAILED");
-            }
+    ≔ peer = Sys·accept(srv, 0, 0);
 
-            // Receive (returns 0 ∈ interpreter - EOF)
-            ≔ received = Sys·recv(sock, 0, 1024, 0);
-            ⎇ received >= 0 {
-                println("recv: OK");
-            } ⎉ {
-                println("recv: FAILED");
-            }
+    // Client to server. The count must be the real count *and* the bytes must
+    // be the bytes: a send that reports its argument without transmitting
+    // passes the first check and fails the second.
+    ≔ sent = Sys·send(cli, "PING-7432", 9, 0);
+    ⎇ sent == 9 { println("send: OK"); } ⎉ { println("send: FAILED"); }
+    ⎇ Sys·recv_string(peer, 64) == "PING-7432" {
+        println("payload arrived intact: OK");
+    } ⎉ { println("payload arrived intact: FAILED"); }
 
-            // Shutdown
-            ≔ shut = Sys·shutdown(sock, SHUT_RDWR());
-            ⎇ shut == 0 {
-                println("shutdown: OK");
-            } ⎉ {
-                println("shutdown: FAILED");
-            }
-        } ⎉ {
-            println("connect: FAILED");
-        }
+    // Server to client, so the direction is not the thing that happens to work.
+    Sys·send(peer, "PONG", 4, 0);
+    ⎇ Sys·recv_string(cli, 64) == "PONG" {
+        println("reply arrived intact: OK");
+    } ⎉ { println("reply arrived intact: FAILED"); }
 
-        // Close
-        ≔ closed = Sys·close(sock);
-        ⎇ closed == 0 {
-            println("close: OK");
-        } ⎉ {
-            println("close: FAILED");
-        }
-    } ⎉ {
-        println("socket: FAILED");
-    }
+    // A shutdown the peer can observe. After the client stops writing, the
+    // server reads EOF -- empty, not blocked, not the previous payload again.
+    // A no-op shutdown leaves the peer waiting instead.
+    ⎇ Sys·shutdown(cli, 1) == 0 { println("shutdown: OK"); } ⎉ { println("shutdown: FAILED"); }
+    ⎇ Sys·recv_string(peer, 64) == "" {
+        println("peer saw EOF: OK");
+    } ⎉ { println("peer saw EOF: FAILED"); }
+
+    Sys·close(peer);
+    Sys·close(srv);
+    ⎇ Sys·close(cli) == 0 { println("close: OK"); } ⎉ { println("close: FAILED"); }
 }

--- a/jormungandr/tests/spec/22_native_runtime/P1_042_socket_server.expected
+++ b/jormungandr/tests/spec/22_native_runtime/P1_042_socket_server.expected
@@ -1,6 +1,9 @@
 socket: OK
-setsockopt: OK
 bind: OK
 listen: OK
+port really taken: OK
+connect: OK
 accept: OK
+accept gave a new fd: OK
+accepted socket carries the data: OK
 close: OK

--- a/jormungandr/tests/spec/22_native_runtime/P1_042_socket_server.sg
+++ b/jormungandr/tests/spec/22_native_runtime/P1_042_socket_server.sg
@@ -1,57 +1,61 @@
-// Test socket server operations
-// This tests bind, listen, accept syscalls
+// Test: socket server operations — bind, listen, accept
+// Spec: 22-NATIVE-RUNTIME.md
 // Priority: P1
+//
+// A real server socket on loopback. This file used to pass `0` as the address
+// and say "Bind to address (simulated)" in its own comments, asserting that
+// each call returned 0 while `Sys·socket` handed back a counter and nothing
+// ever listened (#124). Every assertion below fails against that simulation.
+//
+// Single-threaded on purpose: the client connects before anyone accepts, the
+// listen backlog completes the handshake, and accept then returns at once. No
+// concurrency, so this does not depend on #122.
 
 rite main() {
-    // Test: Create a server socket
-    ≔ sock = Sys·socket(AF_INET(), SOCK_STREAM(), 0);
+    ≔ srv = Sys·socket(2, 1, 0);
+    ⎇ srv < 0 { println("socket: FAILED"); ⤺; }
+    println("socket: OK");
 
-    ⎇ sock >= 0 {
-        println("socket: OK");
+    // SO_REUSEADDR, so a rerun does not hit EADDRINUSE from TIME_WAIT.
+    Sys·setsockopt(srv, 1, 2, 1, 4);
 
-        // Set socket option (reinvoke address)
-        ≔ opt = Sys·setsockopt(sock, SOL_SOCKET(), SO_REUSEADDR(), 0, 4);
-        ⎇ opt == 0 {
-            println("setsockopt: OK");
-        } ⎉ {
-            println("setsockopt: FAILED");
-        }
+    ⎇ Sys·bind(srv, "127.0.0.1:7431", 0) == 0 {
+        println("bind: OK");
+    } ⎉ { println("bind: FAILED"); ⤺; }
 
-        // Bind to address (simulated)
-        ≔ bound = Sys·bind(sock, 0, 16);
-        ⎇ bound == 0 {
-            println("bind: OK");
-        } ⎉ {
-            println("bind: FAILED");
-        }
+    ⎇ Sys·listen(srv, 8) == 0 {
+        println("listen: OK");
+    } ⎉ { println("listen: FAILED"); ⤺; }
 
-        // Listen ∀ connections
-        ≔ listening = Sys·listen(sock, 10);
-        ⎇ listening == 0 {
-            println("listen: OK");
-        } ⎉ {
-            println("listen: FAILED");
-        }
+    // A second bind to the same address must now fail. This is what proves
+    // the first one reached the kernel: a simulated bind that returns 0
+    // cannot make the port unavailable to anyone else.
+    ≔ other = Sys·socket(2, 1, 0);
+    ⎇ Sys·bind(other, "127.0.0.1:7431", 0) != 0 {
+        println("port really taken: OK");
+    } ⎉ { println("port really taken: FAILED"); }
+    Sys·close(other);
 
-        // Accept a connection (simulated - returns new fd)
-        ≔ client = Sys·accept(sock, 0, 0);
-        ⎇ client >= 0 {
-            println("accept: OK");
+    ≔ cli = Sys·socket(2, 1, 0);
+    ⎇ Sys·connect(cli, "127.0.0.1:7431", 0) == 0 {
+        println("connect: OK");
+    } ⎉ { println("connect: FAILED"); ⤺; }
 
-            // Close client socket
-            Sys·close(client);
-        } ⎉ {
-            println("accept: FAILED");
-        }
+    ≔ peer = Sys·accept(srv, 0, 0);
+    ⎇ peer >= 0 { println("accept: OK"); } ⎉ { println("accept: FAILED"); ⤺; }
 
-        // Close server socket
-        ≔ closed = Sys·close(sock);
-        ⎇ closed == 0 {
-            println("close: OK");
-        } ⎉ {
-            println("close: FAILED");
-        }
-    } ⎉ {
-        println("socket: FAILED");
-    }
+    // The accepted descriptor must be a *different* socket from the listener.
+    ⎇ peer != srv { println("accept gave a new fd: OK"); } ⎉ { println("accept gave a new fd: FAILED"); }
+
+    // And it must be the one carrying the client's bytes. A number that is
+    // merely >= 0 proves nothing; this proves accept returned the right
+    // socket.
+    Sys·send(cli, "FROM-CLIENT", 11, 0);
+    ⎇ Sys·recv_string(peer, 64) == "FROM-CLIENT" {
+        println("accepted socket carries the data: OK");
+    } ⎉ { println("accepted socket carries the data: FAILED"); }
+
+    Sys·close(peer);
+    Sys·close(cli);
+    ⎇ Sys·close(srv) == 0 { println("close: OK"); } ⎉ { println("close: FAILED"); }
 }

--- a/parser/src/stdlib.rs
+++ b/parser/src/stdlib.rs
@@ -38682,8 +38682,41 @@ fn register_sys(interp: &mut Interpreter) {
             _ => 0,
         };
 
-        // In interpreter mode, use Rust's std::net
-        // We only support AF_INET (2) with SOCK_STREAM (1) for TCP
+        // A real socket where the platform has one.
+        //
+        // `Sys·bind`, `Sys·listen`, `Sys·accept` and the `Sys·epoll_*` family
+        // all carry native branches already, gated on `fd < FAKE_FD_THRESHOLD`
+        // -- but this function could only ever return a counter starting at
+        // 21000, so through the ordinary `socket -> bind -> listen` sequence
+        // **every one of those branches was unreachable**. `bind` and `listen`
+        // answered 0 from the simulation and nothing listened, which is a
+        // success report for work not done (#124).
+        //
+        // AF_UNIX already took the native path below. This extends the same
+        // treatment to AF_INET, which is the domain every server uses.
+        #[cfg(all(unix, feature = "native"))]
+        {
+            if domain == 2 && (sock_type == 1 || sock_type == 2) {
+                let protocol = match &args[2] {
+                    Value::Int(n) => *n as i32,
+                    _ => 0,
+                };
+                let fd = unsafe { libc::socket(domain, sock_type, protocol) };
+                if fd >= 0 {
+                    // Below FAKE_FD_THRESHOLD by construction -- a real
+                    // descriptor -- so the native branches downstream take it.
+                    return Ok(Value::Int(fd as i64));
+                }
+                // Out of descriptors, or the domain is unavailable in this
+                // sandbox. Report the errno rather than silently simulating:
+                // a caller that cannot open a socket needs to know now, not
+                // when nothing arrives on it.
+                return Ok(Value::Int(-(nix_errno())));
+            }
+        }
+
+        // Non-native builds keep the simulation: there is no libc to call, and
+        // a program that only exercises the sequence still runs.
         if domain == 2 && sock_type == 1 {
             // Create a fake socket fd - actual connection happens on connect
             let fd = FAKE_SOCKET_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst) as i64;
@@ -38721,6 +38754,45 @@ fn register_sys(interp: &mut Interpreter) {
             Value::Int(n) => *n,
             _ => return Err(RuntimeError::new("Sys·connect requires int fd")),
         };
+
+        // Native path for real OS sockets. The address arrives as "host:port"
+        // for the same reason `Sys·bind` takes one: the POSIX sockaddr pointer
+        // has no Sigil spelling.
+        #[cfg(all(unix, feature = "native"))]
+        {
+            if fd >= 0 && fd < FAKE_FD_THRESHOLD {
+                if let Value::String(addr_str) = &args[1] {
+                    let addr: std::net::SocketAddr = match addr_str.parse() {
+                        Ok(a) => a,
+                        Err(_) => return Ok(Value::Int(-22)), // -EINVAL
+                    };
+                    let ret = match addr {
+                        std::net::SocketAddr::V4(v4) => {
+                            // Zeroed and assigned rather than a struct
+                            // literal: `sockaddr_in`'s fields differ across
+                            // unixes (Darwin and the BSDs carry `sin_len`).
+                            let mut sa: libc::sockaddr_in =
+                                unsafe { std::mem::zeroed() };
+                            sa.sin_family = libc::AF_INET as libc::sa_family_t;
+                            sa.sin_port = v4.port().to_be();
+                            sa.sin_addr = libc::in_addr {
+                                s_addr: u32::from_ne_bytes(v4.ip().octets()),
+                            };
+                            unsafe {
+                                libc::connect(
+                                    fd as i32,
+                                    &sa as *const libc::sockaddr_in as *const libc::sockaddr,
+                                    std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
+                                )
+                            }
+                        }
+                        std::net::SocketAddr::V6(_) => return Ok(Value::Int(-97)), // -EAFNOSUPPORT
+                    };
+                    return Ok(Value::Int(if ret == 0 { 0 } else { -(nix_errno()) }));
+                }
+                return Ok(Value::Int(-22)); // -EINVAL: no address we can read
+            }
+        }
 
         // In interpreter mode, we don't actually connect
         // Just mark the socket as connected for testing purposes
@@ -38970,6 +39042,44 @@ fn register_sys(interp: &mut Interpreter) {
             _ => return Err(RuntimeError::new("Sys·send requires int len")),
         };
 
+        // Native path for real OS sockets, as for bind/listen/accept/connect.
+        //
+        // The payload arrives as a String: there is no Sigil spelling for a
+        // raw buffer pointer, which is the same reason `Sys·bind` takes
+        // "host:port" rather than a sockaddr. `len` is honoured as a cap so a
+        // caller can send a prefix, but the bytes come from the argument --
+        // the simulated path below returned `len` without ever reading it,
+        // which is a confirmed transmission that never happened (#167).
+        #[cfg(all(unix, feature = "native"))]
+        {
+            if fd >= 0 && fd < FAKE_FD_THRESHOLD {
+                if let Value::String(payload) = &args[1] {
+                    let bytes = payload.as_bytes();
+                    let n = if len >= 0 && (len as usize) < bytes.len() {
+                        len as usize
+                    } else {
+                        bytes.len()
+                    };
+                    let sent = unsafe {
+                        libc::send(
+                            fd as i32,
+                            bytes.as_ptr() as *const libc::c_void,
+                            n,
+                            0,
+                        )
+                    };
+                    return Ok(Value::Int(if sent < 0 {
+                        -(nix_errno())
+                    } else {
+                        sent as i64
+                    }));
+                }
+                // A real descriptor with no payload we can read. Refusing is
+                // the point: reporting `len` here is the defect.
+                return Ok(Value::Int(-22)); // -EINVAL
+            }
+        }
+
         let is_connected = FAKE_SOCKET_STATE.with(|map| {
             matches!(map.borrow().get(&fd), Some(FakeSocket::Connected))
         });
@@ -38990,6 +39100,32 @@ fn register_sys(interp: &mut Interpreter) {
             _ => return Err(RuntimeError::new("Sys·recv requires int fd")),
         };
 
+        // Native path for real OS sockets, as for its neighbours.
+        //
+        // Returns the byte count, which is the POSIX shape. The bytes
+        // themselves are not retrievable through this spelling, because the
+        // buffer pointer has no Sigil equivalent -- use `Sys·recv_string`
+        // below, which performs the same read and hands back the payload.
+        // Call one or the other: both consume from the socket.
+        #[cfg(all(unix, feature = "native"))]
+        {
+            if fd >= 0 && fd < FAKE_FD_THRESHOLD {
+                let want = match &args[2] {
+                    Value::Int(n) if *n > 0 => *n as usize,
+                    _ => 4096,
+                };
+                let mut buf = vec![0u8; want];
+                let got = unsafe {
+                    libc::recv(fd as i32, buf.as_mut_ptr() as *mut libc::c_void, want, 0)
+                };
+                return Ok(Value::Int(if got < 0 {
+                    -(nix_errno())
+                } else {
+                    got as i64
+                }));
+            }
+        }
+
         let is_connected = FAKE_SOCKET_STATE.with(|map| {
             matches!(map.borrow().get(&fd), Some(FakeSocket::Connected))
         });
@@ -39002,6 +39138,48 @@ fn register_sys(interp: &mut Interpreter) {
         }
     });
 
+    // Sys·recv_string(fd: i64, max_len: i64) -> String
+    //
+    // The payload, rather than a count of it. POSIX `recv` writes into a
+    // caller-supplied buffer and Sigil has no spelling for one, so the byte
+    // count was the only thing `Sys·recv` could return -- which meant nothing
+    // could ever assert what actually crossed the socket, and a `send` that
+    // reported a plausible number for bytes it never read went unnoticed for
+    // exactly that reason (#167).
+    //
+    // Returns "" on EOF or error; use `Sys·recv` when the count is what you
+    // need. Both consume, so use one.
+    define(interp, "Sys·recv_string", Some(2), |_, args| {
+        let fd = match &args[0] {
+            Value::Int(n) => *n,
+            _ => return Err(RuntimeError::new("Sys·recv_string requires int fd")),
+        };
+        let want = match &args[1] {
+            Value::Int(n) if *n > 0 => *n as usize,
+            _ => 4096,
+        };
+
+        #[cfg(all(unix, feature = "native"))]
+        {
+            if fd >= 0 && fd < FAKE_FD_THRESHOLD {
+                let mut buf = vec![0u8; want];
+                let got = unsafe {
+                    libc::recv(fd as i32, buf.as_mut_ptr() as *mut libc::c_void, want, 0)
+                };
+                if got <= 0 {
+                    return Ok(Value::String(Rc::new(String::new())));
+                }
+                buf.truncate(got as usize);
+                return Ok(Value::String(Rc::new(
+                    String::from_utf8_lossy(&buf).into_owned(),
+                )));
+            }
+        }
+        let _ = want;
+        let _ = fd;
+        Ok(Value::String(Rc::new(String::new())))
+    });
+
     // Sys·shutdown(fd: i64, how: i64) -> i64
     // Shut down part of a full-duplex connection. how: 0=SHUT_RD, 1=SHUT_WR, 2=SHUT_RDWR
     define(interp, "Sys·shutdown", Some(2), |_, args| {
@@ -39009,6 +39187,22 @@ fn register_sys(interp: &mut Interpreter) {
             Value::Int(n) => *n,
             _ => return Err(RuntimeError::new("Sys·shutdown requires int fd")),
         };
+
+        // Native path for real OS sockets. Reporting 0 without shutting the
+        // socket down leaves the peer waiting for an EOF that never arrives,
+        // which is the failure the simulation could not distinguish itself
+        // from.
+        #[cfg(all(unix, feature = "native"))]
+        {
+            if fd >= 0 && fd < FAKE_FD_THRESHOLD {
+                let how = match &args[1] {
+                    Value::Int(n) => *n as i32,
+                    _ => libc::SHUT_RDWR,
+                };
+                let ret = unsafe { libc::shutdown(fd as i32, how) };
+                return Ok(Value::Int(if ret == 0 { 0 } else { -(nix_errno()) }));
+            }
+        }
 
         let exists = FAKE_SOCKET_STATE.with(|map| {
             map.borrow().contains_key(&fd)
@@ -39027,6 +39221,42 @@ fn register_sys(interp: &mut Interpreter) {
             Value::Int(n) => *n,
             _ => return Err(RuntimeError::new("Sys·setsockopt requires int fd")),
         };
+
+        // Native path for real OS sockets. Only the int-valued options are
+        // reachable from Sigil -- SO_REUSEADDR and friends -- because the
+        // option value arrives as an integer and there is no spelling for an
+        // arbitrary buffer. That covers what a server actually sets before
+        // binding, which is the case the simulated `Ok(0)` was silently not
+        // doing: a rebind after restart failed with EADDRINUSE despite
+        // setsockopt having reported success.
+        #[cfg(all(unix, feature = "native"))]
+        {
+            if fd >= 0 && fd < FAKE_FD_THRESHOLD {
+                let level = match &args[1] {
+                    Value::Int(n) => *n as i32,
+                    _ => libc::SOL_SOCKET,
+                };
+                let optname = match &args[2] {
+                    Value::Int(n) => *n as i32,
+                    _ => return Ok(Value::Int(-22)), // -EINVAL
+                };
+                let optval: libc::c_int = match &args[3] {
+                    Value::Int(n) => *n as libc::c_int,
+                    Value::Bool(b) => *b as libc::c_int,
+                    _ => 1,
+                };
+                let ret = unsafe {
+                    libc::setsockopt(
+                        fd as i32,
+                        level,
+                        optname,
+                        &optval as *const libc::c_int as *const libc::c_void,
+                        std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+                    )
+                };
+                return Ok(Value::Int(if ret == 0 { 0 } else { -(nix_errno()) }));
+            }
+        }
 
         let exists = FAKE_SOCKET_STATE.with(|map| {
             map.borrow().contains_key(&fd)


### PR DESCRIPTION
Closes #124. Closes #167. (Neither auto-closes — this targets `develop`.)

## The defect

`Sys·socket` never called libc:

```rust
if domain == 2 && sock_type == 1 {
    // Create a fake socket fd - actual connection happens on connect
    let fd = FAKE_SOCKET_COUNTER.fetch_add(1, …) as i64;   // starts at 21000
    …
}
```

`FAKE_FD_THRESHOLD` is 4000, and the native branches in `bind`, `listen` and
`accept` are all gated on `fd < FAKE_FD_THRESHOLD`. Since `Sys·socket` could
only ever return ≥ 21000, **every one of those native branches was unreachable
through the ordinary `socket → bind → listen` sequence.** `bind` and `listen`
returned 0 from the simulation and nothing listened.

```
before:  socket fd = 21000    bind = 0    listen = 0    ss -ltn: nothing
after:   socket fd = 3        bind = 0    listen = 0    ss -ltn: LISTEN 0 128 127.0.0.1:7411
```

## The surface was half-built, and I audited it rather than eyeballing it

My first read of this was wrong — I told the user `connect` had a native branch;
it did not, and my grep had picked up neighbouring `bind` code. Measured
properly, by walking each `define(…)` body and checking for a `native` cfg
block:

| call | native before | native now |
|---|---|---|
| `bind`, `listen`, `accept`, `close` | ✅ | ✅ |
| `socket` | ❌ | **✅** |
| `connect` | ❌ | **✅** |
| `send` | ❌ | **✅** |
| `recv` | ❌ | **✅** |
| `setsockopt` | ❌ | **✅** |
| `shutdown` | ❌ | **✅** |
| `epoll_create1`, `epoll_ctl`, `epoll_wait` | ❌ | ❌ — that is #122 |

`Sys·send` was the worst of them, and is why #167 exists:

```rust
let len = args[2];        // args[1], the buffer, is never read
// In interpreter mode, pretend we sent the data
Ok(Value::Int(len))
```

It confirmed a transmission of bytes it never looked at. `bind` returning 0
means nothing is listening, which the next call usually exposes; `send`
returning `len` means *your bytes went out*, and every layer above treats the
return value as confirmation.

## Payloads are Strings, for a reason already in the tree

There is no Sigil spelling for a raw buffer pointer — which is why `Sys·bind`
already takes `"host:port"` rather than a sockaddr, with a comment saying so.
`send` takes a `String` payload for the same reason, `connect` takes
`"host:port"`, and **`Sys·recv_string` is added** beside `Sys·recv`.

`recv` keeps returning the byte count (the POSIX shape). Without `recv_string`
nothing could assert *what* crossed the socket — which is precisely why a
`send` that returned a plausible number survived this long.

Non-native builds keep the simulation unchanged, so a WASM target still runs
the sequence.

## The two tests that asserted the simulation

Both said so in their own comments — `// Bind to address (simulated)`,
`// Connect (in interpreter mode, this always succeeds)` — and passed `0` as
the address. Rewritten as real loopback tests, **single-threaded**: the client
connects before anyone accepts, the listen backlog completes the handshake, and
`accept` returns at once. No concurrency, so neither depends on #122.

They assert bytes that crossed, not numbers that came back:

| assertion | why a simulation cannot satisfy it |
|---|---|
| received payload == sent payload, **both directions** | a `send` that ignores its buffer transmits nothing |
| a second `bind` to the same address **fails** | a simulated bind cannot make a port unavailable |
| `accept` returns a **different** fd, and it carries the client's bytes | a number ≥ 0 proves nothing about which socket it is |
| after `shutdown`, the peer reads **EOF** | a no-op shutdown leaves the peer waiting |

### Verified by mutation

Reverting `Sys·socket` to the counter and re-running:

```
P1_041 on the MUTANT:
  socket: OK
  connect: OK
  send: OK                          ← the count assertion still passes
  payload arrived intact: FAILED    ← the payload assertion does not
  reply arrived intact: FAILED

P1_042 on the MUTANT:
  bind: OK
  listen: OK
  port really taken: FAILED         ← the side-effect assertion catches it
```

**`send: OK` passing on the mutant is the point.** The simulation returns the
plausible number, so a test asserting `sent == 9` inherits the defect it was
meant to catch — which is exactly what the old file did. Only the payload and
side-effect assertions discriminate.

## Not a regression: `P0_003_websocket_real`

It timed out in one suite run and I nearly reported it as breakage from this
change. Sampled 3× on each build, it passes 3/3 both with and without — the
timeout was transient contention. One red run is no more evidence than one
green one.

## Tests

Measured on `develop` (652dc58) first, same machine, **default features**,
`--no-fail-fast`:

| | develop @ 652dc58 | this branch |
|---|---|---|
| `cargo test --release --no-fail-fast` (lib) | 590 passed / 2 failed | 590 passed / 2 failed |
| bin | 49 passed / 0 failed | 49 passed / 0 failed |
| `jormungandr/tests/run_tests_rust.sh` | 797 / 4 failed / 6 skipped | 797 / 4 failed / 6 skipped |

Expected-red on both sides: the 2 lib failures are
`llvm_codegen::llvm::tests::test_generic_struct_{basic,two_params}`; the 4
suite failures are the Kafka/AMQP broker tests.

Identical totals — `P1_041` and `P1_042` were passing before and pass now, but
they were passing against a simulation and now pass against a socket.

*(Feature set stated deliberately: `--no-default-features --features
minimal,protocols` omits all 47 `llvm_codegen` tests including both known reds,
so it reports a clean green that is not comparable to the above.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcjF6FPweMf1gk7DYXLkWC
