### PR TITLE
fix(parser): let `of` and `each` be names, like the other 90 keywords

### DIFF
--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -7988,9 +7988,14 @@ mod migrate_span_tests {
         // its bracket stack per span sees no enclosing brace here, takes no
         // position, and reports nothing — so it misses the documented field,
         // which is the ordinary shape of the thing this diagnostic is for.
+        // Specimen is `loop`, which is still refused in field position. It used
+        // to be `each` — an ASCII prose alias for `∀` that the parser now
+        // accepts as a field name, so it stopped being a collision and this
+        // test would otherwise be asserting the absence of a defect that was
+        // fixed rather than the bracket-stack behaviour it is for.
         assert_eq!(
-            f("pub struct S {\n    /// Emit extend method.\n    pub each: Option<Each>,\n}"),
-            vec![("each".into(), 1)]
+            f("pub struct S {\n    /// Emit extend method.\n    pub loop: Option<Loop>,\n}"),
+            vec![("loop".into(), 1)]
         );
         assert_eq!(
             f("struct S {\n    pub n: u8, // trailing\n    pub aspect: f32,\n}"),
@@ -8678,14 +8683,22 @@ mod collision_corpus_tests {
     fn a_closure_parameter_is_a_binding() {
         // #84/#89. `this` binds cleanly, so no closure parameter spelled
         // `this` may be reported -- develop carried exactly that as a live
-        // false positive, in cranelift-isle and rustc-demangle. `of` is
-        // refused in every position, so it is a true positive and stays.
+        // false positive, in cranelift-isle and rustc-demangle.
+        //
+        // `of` was here too, on the premise that it "is refused in every
+        // position, so it is a true positive". That premise is no longer true:
+        // `of` is the ASCII prose alias for `∈`, and it now resolves as an
+        // ordinary name in field, parameter and local position like the other
+        // 90 keywords. So it binds cleanly and joins `this` in not being
+        // reported. The detector needed no change to learn this — it probes the
+        // real parser per position, which is exactly why it tracked the change
+        // on its own and this expectation did not.
         //
         // `tome` is counted twice: once for the typed `|mut tome: u32|`,
         // found by its colon, and once for the untyped `|mut tome|` beside it.
         // The untyped form was #91 -- the byte before the name is the `t` of
         // `mut`, so the test had to look one word further back for the bar.
-        expect("closure_params.rs", &[("of", 1), ("tome", 2)]);
+        expect("closure_params.rs", &[("tome", 2)]);
     }
 
     #[test]

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -9684,6 +9684,22 @@ impl<'a> Parser<'a> {
     fn keyword_as_ident(token: &Token) -> Option<&'static str> {
         match token {
             // Common keywords that may be used as field/variable names
+            //
+            // `of` and `each` are the ASCII prose aliases the lexer gives to
+            // `` (ElementOf) and `` (ForAll). They were the only two of the 92
+            // keyword tokens missing from this table, which made them the only
+            // two that could not be a field name: `p.in`, `p.for`, `p.type` and
+            // `p.ref` all parse, and `p.of` does not. #82 closed on the finding
+            // that "a keyword can never legitimately be an identifier" is a
+            // false premise and stopped `migrate` renaming keywords in field
+            // position — true for 90 tokens and false for these two, which is
+            // what let it survive. React's `FacetRail` has a prop named `of`,
+            // and one such field access failed the whole 106-component link.
+            //
+            // The symbol spellings never reach field position, so mapping each
+            // token back to its ASCII spelling is unambiguous in practice.
+            Token::ElementOf => Some("of"),
+            Token::ForAll => Some("each"),
             Token::Packed => Some("packed"),
             Token::As => Some("as"),
             Token::Type => Some("type"),
@@ -11189,6 +11205,45 @@ mod tests {
         let mut parser = Parser::new(source);
         let file = parser.parse_file().unwrap();
         assert_eq!(file.items.len(), 1);
+    }
+
+    /// `of` and `each` are usable as ordinary names, like the other 90 keywords.
+    ///
+    /// They are the ASCII prose aliases the lexer gives to `∈` (ElementOf) and
+    /// `∀` (ForAll), and they were the only two of the 92 keyword tokens missing
+    /// from `keyword_as_ident` — so `p.in`, `p.for`, `p.type` and `p.ref` all
+    /// parsed and `p.of` did not. One such field access failed a 106-component
+    /// project link in the Lares/Qliphoth probe, because React's `FacetRail` has
+    /// a prop named `of`.
+    ///
+    /// The keyword spellings must keep working, which is the other half.
+    #[test]
+    fn of_and_each_are_usable_as_names() {
+        for src in [
+            "rite f(p: Any) -> Any! { ⤺ p.of; }",
+            "rite f(p: Any) -> Any! { ⤺ p.each; }",
+            "sigil S { of: Any }",
+            "sigil S { each: Any }",
+            "rite f(of: Any) -> Any! { ⤺ of; }",
+        ] {
+            let mut parser = Parser::new(src);
+            assert!(
+                parser.parse_file().is_ok(),
+                "should parse as an ordinary name: {src}"
+            );
+        }
+
+        // …and both keep their keyword meaning.
+        for src in [
+            "rite f(xs: Any) -> Any! { ∀ x of xs { x; } ⤺ ∅; }",
+            "rite f(xs: Any) -> Any! { ∀ x ∈ xs { x; } ⤺ ∅; }",
+        ] {
+            let mut parser = Parser::new(src);
+            assert!(
+                parser.parse_file().is_ok(),
+                "keyword use must still parse: {src}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
`keyword_as_ident` maps keyword tokens back to their spelling so they can be field, parameter or local names. It covered **90 of the 92**. The two it missed were `ElementOf` and `ForAll` — and the lexer gives both an ASCII prose alias:

```rust
#[token("")] #[token("of")]    ElementOf
#[token("")] #[token("each")]  ForAll
```

So `of` and `each` were the only two keywords that could not be a name:

```sigil
 rite f(p: Any) -> Any! {  p.in; }    // exit 0
 rite f(p: Any) -> Any! {  p.for; }   // exit 0
 rite f(p: Any) -> Any! {  p.type; }  // exit 0
 rite f(p: Any) -> Any! {  p.ref; }   // exit 0
 rite f(p: Any) -> Any! {  p.of; }    // exit 1  <- parse error
```

## Why it survived

This is the residue of **#82**, which closed on the finding that *"a keyword can never legitimately be an identifier"* is a false premise, and stopped `migrate` renaming keywords in field position. That premise is right for 90 tokens and wrong for two — exactly the shape that survives review.

## How it was found

The Lares/Qliphoth capability probe. React's `FacetRail` has a prop literally named `of`, so `migrate` emitted `= of_ = self.props.of;` — the binding renamed, the access not — and **one field access failed the whole 106-component project link**, since a project build is one module. With this fix that file parses and the link moves on to the next blocker.

Both keyword spellings keep working: `∀ x of xs` and `⊢ Trait each Type` still parse. The symbol forms never reach name position, so the mapping back is unambiguous.

## Two corpus tests updated, both asserting the old behaviour

- **`a_closure_parameter_is_a_binding`** expected `of` reported as a collision, on the stated premise that it *"is refused in every position, so it is a true positive"*. No longer true: `of` now binds cleanly in field, parameter and local position, so it joins `this` in not being reported.

  Worth noting the detector needed **no change**. It probes the real parser once per `NamePosition`, so it tracked the behaviour change on its own — only the hard-coded expectation was stale. That is the design working.

- **`a_comment_does_not_lose_the_enclosing_brace`** used `each` as its specimen. Its subject is the bracket stack surviving a comment, not `each`, so the specimen is now `loop`, which is still refused in field position. Otherwise the test would be asserting the absence of a defect that was fixed rather than the behaviour it exists for.

## Tests

Provenance: **`sigil-lang` `develop` @ `652dc58`, DEFAULT features, `cargo test --release --no-fail-fast`.**

| | all binaries |
|---|---|
| this branch | **640 passed, 2 failed** |
| baseline `652dc58` | 639 passed, 2 failed |

The +1 is the regression test. The two failures are `llvm_codegen::llvm::tests::test_generic_struct_basic` and `test_generic_struct_two_params` — **pre-existing, identical before and after**.

Default features used deliberately: a minimal-flags build does not compile `llvm_codegen` at all, which is exactly where both failures live, so its clean 0 is a false green. And LLVM 18.1.3 is present on this machine, so there is no reason to reach for minimal flags in the first place.

A regression test pins both halves — the five name positions that were rejected, and the two keyword uses that must keep parsing.

Closes #143

 Generated with [Claude Code](https://claude.com/claude-code)
