### PR TITLE
feat(cli): warn when sigil reads a .sigil source file (LARES-363)

### DIFF
--- a/parser/README.md
+++ b/parser/README.md
@@ -61,6 +61,23 @@ cargo build --release
 ./program
 ```
 
+## `.sg` is the canonical source extension
+
+`.sg` is the canonical Sigil source extension; `.sigil` is deprecated but still
+compiles. Reading a `.sigil` file prints a warning naming the path, at every
+command that reads source (`run`, `run-dir`, `run-ws`, `jit`, `llvm`, `compile`,
+`wasm`, `rust`, `check`, `lint`, `dump-ir`, `doc-extract`, `parse`, `lex`,
+`test`, `build`). A `.sg` file never triggers it. Suppress it globally with
+`--no-deprecation-warnings`.
+
+```bash
+./target/release/sigil run legacy.sigil
+# warning: `legacy.sigil` uses the deprecated `.sigil` extension; rename to `.sg` (suppress with --no-deprecation-warnings)
+
+./target/release/sigil run legacy.sigil --no-deprecation-warnings
+# (no warning)
+```
+
 ## Building with LLVM Backend
 
 For production performance, build with LLVM support:

--- a/parser/src/fmt.rs
+++ b/parser/src/fmt.rs
@@ -385,6 +385,7 @@ impl Formatter {
 /// Format a file in place
 pub fn format_file(path: &Path, config: &FormatConfig) -> Result<bool, String> {
     let source = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+    crate::warn_if_deprecated_extension(path);
 
     let formatter = Formatter::new(config.clone());
     let formatted = formatter.format_source(&source)?;
@@ -401,6 +402,7 @@ pub fn format_file(path: &Path, config: &FormatConfig) -> Result<bool, String> {
 /// Check if a file is formatted
 pub fn check_file(path: &Path, config: &FormatConfig) -> Result<bool, String> {
     let source = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+    crate::warn_if_deprecated_extension(path);
 
     let formatter = Formatter::new(config.clone());
     let formatted = formatter.format_source(&source)?;

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -46,6 +46,98 @@ macro_rules! sigil_warn {
     };
 }
 
+/// Global switch for the `.sigil`-extension deprecation warning (LARES-363).
+/// Set via `set_deprecation_warnings(false)` or the `--no-deprecation-warnings` CLI flag.
+static DEPRECATION_WARNINGS: AtomicBool = AtomicBool::new(true);
+
+/// Enable or disable the `.sigil` deprecation warning process-wide.
+pub fn set_deprecation_warnings(enabled: bool) {
+    DEPRECATION_WARNINGS.store(enabled, Ordering::SeqCst);
+}
+
+/// Check whether the `.sigil` deprecation warning is enabled.
+pub fn deprecation_warnings_enabled() -> bool {
+    DEPRECATION_WARNINGS.load(Ordering::SeqCst)
+}
+
+/// Whether `path` carries the deprecated `.sigil` extension. Pure and
+/// independent of the enabled/dedup state, so the extension rule itself is
+/// unit-testable without touching global state or stderr.
+pub fn is_deprecated_sigil_extension<P: AsRef<std::path::Path>>(path: P) -> bool {
+    path.as_ref().extension().map_or(false, |ext| ext == "sigil")
+}
+
+/// Warn once per process, per path, when a `.sigil` source file is read.
+///
+/// `.sg` is the canonical extension; `.sigil` is deprecated but keeps
+/// compiling (LARES-363) — this only names the path and points at the
+/// replacement. A `.sg` file (or anything else) triggers nothing.
+/// Suppressible via `--no-deprecation-warnings` or `set_deprecation_warnings(false)`.
+pub fn warn_if_deprecated_extension<P: AsRef<std::path::Path>>(path: P) {
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    if !deprecation_warnings_enabled() {
+        return;
+    }
+
+    let path = path.as_ref();
+    if !is_deprecated_sigil_extension(path) {
+        return;
+    }
+
+    static WARNED: Mutex<Option<HashSet<std::path::PathBuf>>> = Mutex::new(None);
+    let mut guard = WARNED.lock().unwrap();
+    let seen = guard.get_or_insert_with(HashSet::new);
+    if seen.insert(path.to_path_buf()) {
+        eprintln!(
+            "warning: `{}` uses the deprecated `.sigil` extension; rename to `.sg` (suppress with --no-deprecation-warnings)",
+            path.display()
+        );
+    }
+}
+
+#[cfg(test)]
+mod deprecation_warning_tests {
+    use super::*;
+
+    // AC: "A `.sigil` file emits the warning... A `.sg` file emits NOTHING.
+    // A warning that fires on both is noise." This is the rule itself, kept
+    // separate from the printing/dedup side effects so it can be asserted
+    // directly rather than by scraping stderr.
+    #[test]
+    fn sigil_extension_is_flagged() {
+        assert!(is_deprecated_sigil_extension("foo.sigil"));
+        assert!(is_deprecated_sigil_extension("dir/nested/lib.sigil"));
+    }
+
+    #[test]
+    fn sg_extension_is_not_flagged() {
+        assert!(!is_deprecated_sigil_extension("foo.sg"));
+        assert!(!is_deprecated_sigil_extension("dir/nested/lib.sg"));
+    }
+
+    #[test]
+    fn unrelated_extensions_are_not_flagged() {
+        assert!(!is_deprecated_sigil_extension("foo.rs"));
+        assert!(!is_deprecated_sigil_extension("Sigil.toml"));
+        assert!(!is_deprecated_sigil_extension("noext"));
+    }
+
+    // The only test that touches the global suppression switch; every other
+    // test in this module must leave it alone, since `cargo test` runs tests
+    // in parallel within one process and the flag is process-wide.
+    #[test]
+    fn suppression_flag_round_trips() {
+        let original = deprecation_warnings_enabled();
+        set_deprecation_warnings(false);
+        assert!(!deprecation_warnings_enabled());
+        set_deprecation_warnings(true);
+        assert!(deprecation_warnings_enabled());
+        set_deprecation_warnings(original);
+    }
+}
+
 pub mod ast;
 pub mod cfg;
 pub mod diagnostic;

--- a/parser/src/lint.rs
+++ b/parser/src/lint.rs
@@ -3692,6 +3692,7 @@ pub fn lint_directory(dir: &Path, config: LintConfig) -> DirectoryLintResult {
 
     for path in files {
         if let Ok(source) = fs::read_to_string(&path) {
+            crate::warn_if_deprecated_extension(&path);
             let path_str = path.display().to_string();
             let diagnostics = lint_source_with_config(&source, &path_str, config.clone());
 
@@ -3736,6 +3737,7 @@ pub fn lint_directory_parallel(dir: &Path, config: LintConfig) -> DirectoryLintR
         .par_iter()
         .filter_map(|path| {
             let source = fs::read_to_string(path).ok()?;
+            crate::warn_if_deprecated_extension(path);
             let path_str = path.display().to_string();
             let diagnostics = lint_source_with_config(&source, &path_str, config.clone());
 
@@ -5186,6 +5188,7 @@ pub fn lint_directory_filtered(
         .par_iter()
         .filter_map(|path| {
             let source = std::fs::read_to_string(path).ok()?;
+            crate::warn_if_deprecated_extension(path);
             let path_str = path.display().to_string();
             let diagnostics = lint_source_with_config(&source, &path_str, config.clone());
 

--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -7,7 +7,10 @@ use sigil_parser::span::Span;
 use sigil_parser::typeck::TypeChecker;
 #[cfg(feature = "jit")]
 use sigil_parser::JitCompiler;
-use sigil_parser::{register_stdlib, set_verbose, Diagnostic, Diagnostics, Interpreter, Lexer, Parser, Token};
+use sigil_parser::{
+    register_stdlib, set_deprecation_warnings, set_verbose, warn_if_deprecated_extension,
+    Diagnostic, Diagnostics, Interpreter, Lexer, Parser, Token,
+};
 #[cfg(feature = "llvm")]
 use sigil_parser::{CompileMode, LlvmCompiler, OptLevel};
 #[cfg(feature = "wasm")]
@@ -91,9 +94,15 @@ fn main() -> ExitCode {
         set_verbose(true);
     }
 
+    // Handle --no-deprecation-warnings globally (LARES-363: suppresses the
+    // `.sigil`-extension deprecation warning across every subcommand).
+    if args.iter().any(|a| a == "--no-deprecation-warnings") {
+        set_deprecation_warnings(false);
+    }
+
     // Filter out global flags for command processing
     let args: Vec<String> = args.into_iter()
-        .filter(|a| a != "--verbose" && a != "-v")
+        .filter(|a| a != "--verbose" && a != "-v" && a != "--no-deprecation-warnings")
         .collect();
 
     if args.len() >= 2 && (args[1] == "--version" || args[1] == "-V" || args[1] == "version") {
@@ -148,6 +157,10 @@ fn main() -> ExitCode {
         eprintln!("  --pretty            Pretty-print JSON output (default)");
         eprintln!("  --compact           Single-line JSON output");
         eprintln!("  -o <file>           Write IR to file instead of stdout");
+        eprintln!();
+        eprintln!("Global Options:");
+        eprintln!("  --verbose, -v            Enable verbose debug output");
+        eprintln!("  --no-deprecation-warnings  Suppress the `.sigil`-extension deprecation warning");
         return ExitCode::from(1);
     }
 
@@ -635,6 +648,7 @@ fn run_file(path: &str, program_args: &[String], skip_typecheck: bool) -> ExitCo
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(path);
 
     // Parse
     let mut parser = Parser::new(&source);
@@ -803,6 +817,7 @@ fn run_directory(dir_path: &str, program_args: &[String]) -> ExitCode {
                 return ExitCode::from(1);
             }
         };
+        warn_if_deprecated_extension(file_path);
 
         // Get module name from filename (without extension)
         let module_name = Path::new(file_path)
@@ -1042,6 +1057,7 @@ fn run_workspace(bin_name: Option<&str>, program_args: &[String]) -> ExitCode {
                     continue;
                 }
             };
+            warn_if_deprecated_extension(file_path);
 
             let mut parser = Parser::new(&source);
             match parser.parse_file() {
@@ -1205,6 +1221,7 @@ fn run_workspace(bin_name: Option<&str>, program_args: &[String]) -> ExitCode {
                     return ExitCode::from(1);
                 }
             };
+            warn_if_deprecated_extension(file_path);
 
             let mut parser = Parser::new(&source);
             let ast = match parser.parse_file() {
@@ -1255,6 +1272,7 @@ fn jit_file(path: &str) -> ExitCode {
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(path);
 
     // Create JIT compiler
     let mut jit = match JitCompiler::new() {
@@ -1383,6 +1401,7 @@ fn llvm_file(path: &str) -> ExitCode {
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(path);
 
     if let Err(code) = typecheck_before_codegen(path, &source) {
         return code;
@@ -1445,6 +1464,7 @@ fn compile_file(path: &str, output: &str, use_lto: bool, use_tls: bool, use_cuda
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(path);
 
     if let Err(code) = typecheck_before_codegen(path, &source) {
         return code;
@@ -1905,6 +1925,7 @@ fn rust_compile_file(
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(path);
 
     if let Err(code) = typecheck_before_codegen(path, &source) {
         return code;
@@ -2069,6 +2090,7 @@ fn rust_compile_workspace(
                         continue;
                     }
                 };
+                warn_if_deprecated_extension(&path);
 
                 let mut parser = Parser::new(&source);
                 let source_file = match parser.parse_file() {
@@ -2452,6 +2474,7 @@ fn wasm_compile_file(path: &str, output: &str) -> ExitCode {
         // Single file compilation
         match fs::read_to_string(path) {
             Ok(source) => {
+                warn_if_deprecated_extension(path);
                 if let Err(code) = typecheck_before_codegen(&path.display().to_string(), &source) {
                     return code;
                 }
@@ -2660,7 +2683,10 @@ fn collect_check_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
 
 fn check_single_file(path: &str, format: OutputFormat, quiet: bool, apply_fixes: bool, strict: bool) -> ExitCode {
     let source = match fs::read_to_string(path) {
-        Ok(s) => s,
+        Ok(s) => {
+            warn_if_deprecated_extension(path);
+            s
+        }
         Err(e) => {
             if format == OutputFormat::Human && !quiet {
                 eprintln!("Error reading file '{}': {}", path, e);
@@ -3042,6 +3068,7 @@ fn lint_path(path: &str, format: OutputFormat, config_path: Option<&str>, apply_
                 return ExitCode::from(1);
             }
         };
+        warn_if_deprecated_extension(path);
 
         // Run the linter with config
         let diagnostics = lint_source_with_config(&source, path, config);
@@ -3221,6 +3248,7 @@ fn dump_ir_file(path: &str, pretty: bool, output: Option<&str>) -> ExitCode {
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(path);
 
     // Parse the source
     let mut parser = Parser::new(&source);
@@ -3273,6 +3301,7 @@ fn doc_extract_file(path: &str, format: &str, output: Option<&str>) -> ExitCode 
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(path);
 
     // Parse the source
     let mut parser = Parser::new(&source);
@@ -3490,6 +3519,7 @@ fn parse_file(path: &str) -> ExitCode {
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(path);
 
     let mut parser = Parser::new(&source);
     match parser.parse_file() {
@@ -3603,6 +3633,7 @@ fn lex_file(path: &str) -> ExitCode {
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(path);
 
     println!("Tokens in '{}':", path);
     let mut lexer = Lexer::new(&source);
@@ -4500,6 +4531,7 @@ fn run_test_files(
                 continue;
             }
         };
+        warn_if_deprecated_extension(test_file);
 
         let mut parser = Parser::new(&source);
         let ast = match parser.parse_file() {
@@ -5236,6 +5268,7 @@ fn build_library(name: &str, lib_file: &std::path::Path, target_dir: &std::path:
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(lib_file);
 
     let mut parser = Parser::new(&source);
     let ast = match parser.parse_file() {
@@ -5282,6 +5315,7 @@ fn build_binary(name: &str, main_file: &std::path::Path, target_dir: &std::path:
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(main_file);
 
     let mut parser = Parser::new(&source);
     let ast = match parser.parse_file() {
@@ -5331,6 +5365,7 @@ fn build_binary_with_deps(name: &str, main_file: &std::path::Path, target_dir: &
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(main_file);
 
     let mut parser = Parser::new(&source);
     let ast = match parser.parse_file() {
@@ -5387,6 +5422,7 @@ fn compile_file_with_deps(path: &str, output: &str, dep_libs: &[std::path::PathB
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(path);
 
     // Create LLVM context and compiler in AOT mode
     let context = Context::create();
@@ -5491,6 +5527,7 @@ fn compile_library(path: &str, name: &str, target_dir: &std::path::Path) -> Exit
             return ExitCode::from(1);
         }
     };
+    warn_if_deprecated_extension(path);
 
     // Create LLVM context and compiler in AOT mode
     let context = Context::create();
@@ -8975,7 +9012,7 @@ mod run_directory_tests {
 /// amdusias invisible to `has_lib`/`has_bin` in the first place.
 #[cfg(test)]
 mod build_subsystem_tests {
-    use super::{build_workspace, collect_check_files, find_manifest_path, resolve_source_file, Manifest};
+    use super::{build_workspace, check_single_file, collect_check_files, find_manifest_path, resolve_source_file, Manifest, OutputFormat};
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::process::ExitCode;
@@ -9186,5 +9223,27 @@ mod build_subsystem_tests {
             ExitCode::SUCCESS,
             "the only declared member had no manifest, so nothing was built"
         );
+    }
+
+    // ---- LARES-363: the deprecation warning must not become a rejection ---
+
+    #[test]
+    fn check_single_file_still_succeeds_for_dot_sigil_extension() {
+        let dir = TempDir::new("check-sigil-still-compiles");
+        let file = dir.write("minimal.sigil", "rite main() {}\n");
+        let code = check_single_file(&file.to_string_lossy(), OutputFormat::Human, true, false, false);
+        assert_eq!(
+            code,
+            ExitCode::SUCCESS,
+            ".sigil must keep compiling alongside the deprecation warning (LARES-363)"
+        );
+    }
+
+    #[test]
+    fn check_single_file_succeeds_identically_for_dot_sg_extension() {
+        let dir = TempDir::new("check-sg-baseline");
+        let file = dir.write("minimal.sg", "rite main() {}\n");
+        let code = check_single_file(&file.to_string_lossy(), OutputFormat::Human, true, false, false);
+        assert_eq!(code, ExitCode::SUCCESS);
     }
 }


### PR DESCRIPTION
## Summary

`.sg` is now the canonical Sigil source extension; `.sigil` is deprecated but keeps compiling everywhere it did before. This lands the compiler warning first, per LARES-363 -- no files are renamed in any repo by this change.

- Every command that reads Sigil source (`run`, `run-dir`, `run-ws`, `jit`, `llvm`, `compile`, `wasm`, `rust`, `check`, `lint`, `dump-ir`, `doc-extract`, `parse`, `lex`, `test`, `build`) now warns once per `.sigil` file read, naming the path and pointing at `.sg`. A `.sg` file never triggers it.
- Suppressible globally via `--no-deprecation-warnings`, documented in the CLI's own usage text and in `parser/README.md`.
- `.sigil` still compiles: new tests assert `check_single_file` succeeds identically for `.sigil` and `.sg`.

## Why the change touches more than the "eight `ext ==` sites"

Those sites are mostly directory-listing filters, not the point where a file is actually read and parsed as source -- that happens later, sometimes in a different function. The warning is placed at every `fs::read_to_string` call site that treats its result as Sigil source (found by tracing each CLI entry point), which is a larger, more precise set. `migrate` is deliberately excluded: its `.sigil`/`.sg` acceptance is for scanning already-migrated output, not compiling Sigil source. Full rationale in the findings doc posted to LARES-363.

## Test plan

- [x] `cargo check`/`cargo build` under `jit,native,protocols`, `+llvm`, and `+llvm,wasm` feature combinations -- clean
- [x] `cargo test --lib` (new `deprecation_warning_tests`, 4/4) and `cargo test --bin sigil` (62/62, incl. 2 new) -- 612 passed, 2 pre-existing `llvm_codegen` failures unrelated to this change (`test_generic_struct_basic`, `test_generic_struct_two_params`)
- [x] `jormungandr/tests/run_tests_rust.sh` (release build): 797 passed / 4 failed (known Kafka/AMQP infra-dependent) / 6 skipped -- matches `docs/specs/INTERPRETER-SPEC-ROADMAP.md`, no regressions
- [x] Manual smoke test: mixed `.sigil`+`.sg` directory via `run-dir` warns only on the `.sigil` file; `--no-deprecation-warnings` suppresses it; `.sigil` compiles successfully via `check`/`run`/`compile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
