### PR TITLE
LARES-366: fix the two llvm_codegen generic-struct tests that are red on develop

### DIFF
--- a/parser/src/llvm_codegen.rs
+++ b/parser/src/llvm_codegen.rs
@@ -3035,7 +3035,7 @@ pub mod llvm {
             match &struct_def.fields {
                 ast::StructFields::Named(fields) => {
                     for (idx, field) in fields.iter().enumerate() {
-                        let llvm_type = self.type_expr_to_llvm(&field.ty, type_substitutions);
+                        let llvm_type = self.field_slot_type(&field.ty, type_substitutions);
                         field_types.push(llvm_type);
                         field_indices.insert(field.name.name.clone(), idx as u32);
 
@@ -3050,7 +3050,7 @@ pub mod llvm {
                 }
                 ast::StructFields::Tuple(types) => {
                     for (idx, ty) in types.iter().enumerate() {
-                        let llvm_type = self.type_expr_to_llvm(ty, type_substitutions);
+                        let llvm_type = self.field_slot_type(ty, type_substitutions);
                         field_types.push(llvm_type);
                         field_indices.insert(format!("{}", idx), idx as u32);
                     }
@@ -3074,6 +3074,35 @@ pub mod llvm {
             );
 
             Ok(())
+        }
+
+        /// Give a struct field the 8-byte slot the Sigil LLVM ABI allots it.
+        ///
+        /// Every store into a struct field and every load back out of one in
+        /// this backend is 8 bytes wide, and the offset-based field paths
+        /// address field `i` at byte `i * 8` (see the `Expr::Field` arm, and
+        /// the `field_indices.len() * 8` allocation in the struct-literal
+        /// arm). A field whose source type is narrower than that -- `i32`,
+        /// `bool`, `f32` -- would make `build_struct_gep` compute a *packed*
+        /// offset instead: in `Container<T> { value: T, count: i32 }` with
+        /// `T = i32`, the writer puts `count` at byte 4 while the reader looks
+        /// for it at byte 8. Widening the slot keeps the two in step. Only the
+        /// layout changes; the value living in the slot is an i64 either way.
+        fn field_slot_type(
+            &mut self,
+            ty: &ast::TypeExpr,
+            substitutions: &HashMap<String, String>,
+        ) -> BasicTypeEnum<'ctx> {
+            let llvm_type = self.type_expr_to_llvm(ty, substitutions);
+            match llvm_type {
+                BasicTypeEnum::IntType(t) if t.get_bit_width() < 64 => {
+                    self.context.i64_type().into()
+                }
+                BasicTypeEnum::FloatType(t) if t == self.context.f32_type() => {
+                    self.context.i64_type().into()
+                }
+                other => other,
+            }
         }
 
         /// Convert a TypeExpr to an LLVM BasicTypeEnum
@@ -19897,6 +19926,30 @@ pub mod llvm {
             "#,
             );
             assert_eq!(result.unwrap(), 30);
+        }
+
+        #[test]
+        fn test_struct_narrow_fields_keep_their_eight_byte_slots() {
+            // The generic-struct failures were not about generics: any field
+            // narrower than 8 bytes had the writer using a packed GEP offset
+            // while every reader addressed field `i` at byte `i * 8`. A plain
+            // struct of i32s pins the ABI down directly, so a regression here
+            // names the cause rather than the symptom.
+            let result = run_sigil(
+                r#"
+                Σ Counter {
+                    lo: i32,
+                    mid: i32,
+                    hi: i32,
+                }
+
+                rite main() -> i64 {
+                    ≔ c = Counter { lo: 1, mid: 2, hi: 3 };
+                    c.lo + c.mid + c.hi
+                }
+            "#,
+            );
+            assert_eq!(result.unwrap(), 6);
         }
 
         // ============================================


### PR DESCRIPTION
## The two reds

`llvm_codegen::test_generic_struct_basic` and `test_generic_struct_two_params` have been
failing on `develop` itself — identically on ubuntu-latest and macos-latest, `844 passed,
2 failed`. They were invisible until LARES-353 made this CI capable of failing. Reproduced
locally on `develop @ e96c190` before changing anything, with the same build and flags CI
uses: **lib 844 passed / 2 failed, bin 62 passed / 0 failed.**

## What the assertions actually said

```
test_generic_struct_basic:      left: 4294967338   right: 43
test_generic_struct_two_params: left: 85899345930  right: 30
```

`4294967338 == 42 | (1 << 32)` and `85899345930 == 10 | (20 << 32)`. Two 32-bit fields
sitting inside one 64-bit read, and the second field reading as zero.

## Cause — not generics

`register_concrete_struct` built the LLVM struct layout out of the *source* field types,
so `Container<T> { value: T, count: i32 }` at `T = i32` became `{i32, i32}`.

But every store into a struct field and every load back out of one in this backend is
8 bytes wide, and the offset-based reader addresses field `i` at byte `i * 8` — its own
comment says *"each field is 8 bytes (i64) in Sigil ABI"*, and the struct-literal arm
allocates `field_indices.len() * 8`. So the writer's `build_struct_gep` put `count` at
byte **4** while the reader looked for it at byte **8**. The debug trace shows both halves
disagreeing:

```
[G63-STRUCT] creating struct 'Container_i32', found in struct_types: true   ← writer, {i32,i32}
[G63-DEBUG] looking for 'Container' in struct_types, found: false
[G63-DEBUG] found field 'count' in generic struct 'Container' at idx 1      ← reader, idx*8
```

`value` read 8 bytes from byte 0 and swept up `count` in its high half; `count` read byte
8, which nothing had written, and got zero. Hence `42|(1<<32) + 0`.

## The fix

A `field_slot_type` helper widens any field type narrower than 8 bytes to the i64 slot the
rest of the backend already assumes, and both the named- and tuple-field layout arms go
through it. Only the layout moves — the value living in the slot was an i64 before and
after. Types already 8 bytes (`i64`, `f64`) are untouched, so float field strides are
unchanged.

This was never specific to generics: a plain struct of `i32`s misbehaved the same way. The
added regression test uses one, so a future regression names the cause rather than the
symptom.

## Verification

Same build and flags as the CI job
(`--release --no-default-features --features jit,llvm,wasm,lsp,protocols --no-fail-fast`):

| | lib | bin |
|---|---|---|
| before, `develop @ e96c190`, no change | **844 passed / 2 failed** | 62 passed / 0 failed |
| after | **847 passed / 0 failed** | **62 passed / 0 failed** |

`847 = 844 already passing + 2 repaired + 1 added`. The ticket anticipated 846; the extra
one is the non-generic regression test described above, called out here rather than left
for a reader to reconcile.

No test is skipped, no assertion weakened, no tolerance widened. Both named tests pass on
their original assertions, unedited. The bin suite stays 62/62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
